### PR TITLE
Completely revamp issue reporting

### DIFF
--- a/hedvalidation/hed/validator/error_reporter.py
+++ b/hedvalidation/hed/validator/error_reporter.py
@@ -5,7 +5,8 @@ This module is used to report errors found in the validation.
 
 
 def report_error_type(error_type, error_row=1, error_column=1, hed_string='', tag='', tag_prefix='', previous_tag='',
-                      character='', index=0, unit_class_units='', opening_bracket_count=0, closing_bracket_count=0):
+                      character='', index=0, unit_class_units='', opening_parentheses_count=0,
+                      closing_parentheses_count=0):
     """Reports the abc error based on the type of error.
 
     Parameters
@@ -30,34 +31,38 @@ def report_error_type(error_type, error_row=1, error_column=1, hed_string='', ta
         The character in the string that generated the error.
     unit_class_units: str
         The unit class units that are associated with the error.
-    opening_bracket_count: int
-        The number of opening brackets.
-    closing_bracket_count: int
-        The number of closing brackets.
+    opening_parentheses_count: int
+        The number of opening parentheses.
+    closing_parentheses_count: int
+        The number of closing parentheses.
     Returns
     -------
-    str
-        A error message related to a particular type of error.
+    list of dict
+        A singleton list containing a dictionary with the error type and error message related to a particular type of
+        error.
 
     """
     error_types = {
-        'bracket': '\tERROR: Number of opening and closing parentheses are unequal. %s opening parentheses. %s '
-                   'closing parentheses\n' % (opening_bracket_count, closing_bracket_count),
-        'character': '\tERROR: Invalid character \"%s\"\n' % tag,
-        'comma': '\tERROR: Comma missing after - \"%s\"\n' % tag,
-        'commaValid': '\tERROR: Either \"%s\" contains a comma when it should not or \"%s\" is not a valid tag\n'
-                      % (previous_tag, tag),
-        'duplicate': '\tERROR: Duplicate tag - \"%s\"\n' % tag,
-        'isNumeric': '\tERROR: Invalid numeric tag - \"%s\"\n' % tag,
+        'parentheses': '\tERROR: Number of opening and closing parentheses are unequal. %s opening parentheses. %s '
+                       'closing parentheses\n' % (opening_parentheses_count, closing_parentheses_count),
+        'invalidCharacter': '\tERROR: Invalid character "%s" at index %s of string "%s"'
+                            % (character, index, hed_string),
+        'commaMissing': '\tERROR: Comma missing after - "%s"\n' % tag,
+        'extraCommaOrInvalid': '\tERROR: Either "%s" contains a comma when it should not or "%s" is not a valid '
+                               'tag\n ' % (previous_tag, tag),
+        'duplicateTag': '\tERROR: Duplicate tag - "%s"\n' % tag,
         'row': 'Issues in row %s:\n' % str(error_row),
         'column': 'Issues in row %s column %s:\n' % (str(error_row), str(error_column)),
-        'requireChild': '\tERROR: Descendant tag required - \"%s\"\n' % tag,
-        'tilde': '\tERROR: Too many tildes - group \"%s\"\n' % tag,
-        'unique': '\tERROR: Multiple unique tags with prefix - \"%s\"\n' % tag_prefix,
-        'unitClass': '\tERROR: Invalid unit - \"%s\" valid units are "%s"\n' % (tag, unit_class_units),
-        'valid': '\tERROR: Invalid tag - \"%s\"\n' % tag,
-        'extraDelimiter': '\tERROR: Extra delimiter \"%s\" at index %s of string \"%s\"'
+        'childRequired': '\tERROR: Descendant tag required - "%s"\n' % tag,
+        'tooManyTildes': '\tERROR: Too many tildes - group "%s"\n' % tag,
+        'multipleUniqueTags': '\tERROR: Multiple unique tags with prefix - "%s"\n' % tag_prefix,
+        'unitClassInvalidUnit': '\tERROR: Invalid unit - "%s" valid units are "%s"\n' % (tag, unit_class_units),
+        'invalidTag': '\tERROR: Invalid tag - "%s"\n' % tag,
+        'extraDelimiter': '\tERROR: Extra delimiter "%s" at index %s of string "%s"'
                           % (character, index, hed_string),
-        'invalidCharacter': '\tERROR: ',
     }
-    return error_types.get(error_type, None)
+    default_error_message = 'ERROR: Unknown error'
+    error_message = error_types.get(error_type, default_error_message)
+
+    error_object = {'code': error_type, 'message': error_message}
+    return [error_object]

--- a/hedvalidation/hed/validator/hed_dictionary.py
+++ b/hedvalidation/hed/validator/hed_dictionary.py
@@ -1,11 +1,11 @@
-'''
+"""
 This module contains the Hed_Dictionary class which encapsulates all HED tags, tag attributes, unit classes, and
 unit class attributes in a dictionary.
 
 The dictionary is a dictionary of dictionaries. The dictionary names are
 'default', 'extensionAllowed', 'isNumeric', 'position', 'predicateType', 'recommended', 'required', 'requireChild',
 'tags', 'takesValue', 'unique', 'units', and 'unitClass'.
-'''
+"""
 
 from defusedxml.lxml import parse
 
@@ -33,7 +33,7 @@ class HedDictionary:
 
         Parameters
         ----------
-        hed_xml_file_path: string
+        hed_xml_file_path: str
             The path to a HED XML file.
 
         Returns
@@ -68,24 +68,23 @@ class HedDictionary:
 
         Returns
         -------
-        dictionary
+        dict
             A dictionary of dictionaries that contains all of the tags, tag attributes, unit class units, and unit
             class attributes
 
         """
         return self.dictionaries
 
-    # make changes to add hasUnitClasses and hasUnitModifier here?
     def _populate_dictionaries(self):
-        """Populates a dictionary of dictionaries that contains all of the tags, tag attributes, unit class units, and unit
-           class attributes.
+        """Populates a dictionary of dictionaries that contains all of the tags, tag attributes, unit class units,
+           and unit class attributes.
 
         Parameters
         ----------
 
         Returns
         -------
-        dictionary
+        dict
             A dictionary of dictionaries that contains all of the tags, tag attributes, unit class units, and unit class
             attributes.
 
@@ -103,7 +102,7 @@ class HedDictionary:
 
         Returns
         -------
-        dictionary
+        dict
             A dictionary of dictionaries that has been populated with dictionaries associated with tag attributes.
 
         """
@@ -133,13 +132,12 @@ class HedDictionary:
 
         Returns
         -------
-        dictionary
+        dict
             A dictionary of dictionaries associated with all of the unit classes, unit class units, and unit class
             default units.
 
         """
         unit_class_elements = self._get_elements_by_name(self.UNIT_CLASS_ELEMENT)
-        ## NEW ##
         if len(unit_class_elements) == 0:
             self.has_unit_classes = False
             return
@@ -155,7 +153,6 @@ class HedDictionary:
 
         """
         unit_modifier_elements = self._get_elements_by_name(self.UNIT_MODIFIER_ELEMENT)
-        ## NEW ##
         if len(unit_modifier_elements) == 0:
             self.has_unit_modifiers = False
             return
@@ -177,7 +174,7 @@ class HedDictionary:
 
         Returns
         -------
-        dictionary
+        dict
             A dictionary that contains all the unit class units.
 
         """
@@ -210,7 +207,7 @@ class HedDictionary:
 
         Returns
         -------
-        dictionary
+        dict
             A dictionary that contains all the unit class default units.
 
         """
@@ -233,12 +230,12 @@ class HedDictionary:
             A list containing tags that have a specific attribute.
         tag_element_list: list
             A list containing tag elements that have a specific attribute.
-        attribute_name: string
+        attribute_name: str
             The name of the attribute associated with the tags and tag elements.
 
         Returns
         -------
-        dictionary
+        dict
             The attribute dictionary that has been populated with dictionaries associated with tags.
 
         """
@@ -258,7 +255,7 @@ class HedDictionary:
 
         Returns
         -------
-        dictionary
+        dict
             A dictionary containing the strings in the list.
 
         """
@@ -272,7 +269,7 @@ class HedDictionary:
 
         Parameters
         ----------
-        hed_xml_file_path: string
+        hed_xml_file_path: str
             The path to a HED XML file.
 
         Returns
@@ -314,12 +311,12 @@ class HedDictionary:
         ----------
         element: Element
             A element in the HED XML file.
-        tag_name: string
+        tag_name: str
             The name of the XML element's tag. The default is 'name'.
 
         Returns
         -------
-        string
+        str
             The value of the element's tag. If the element doesn't have the tag then it will return an empty string.
 
         """
@@ -335,7 +332,7 @@ class HedDictionary:
 
         Returns
         -------
-        string
+        str
             The name of the tag element's parent. If there is no parent tag then an empty string is returned.
 
         """
@@ -355,7 +352,7 @@ class HedDictionary:
 
         Returns
         -------
-        string
+        str
             A tag path which is typically referred to as a tag. The tag and it's ancestor tags will be separated by /'s.
 
         """
@@ -369,7 +366,7 @@ class HedDictionary:
 
         Parameters
         ----------
-        attribute_name: string
+        attribute_name: str
             The name of the attribute associated with the tags.
 
         Returns
@@ -390,7 +387,7 @@ class HedDictionary:
 
         Parameters
         ----------
-        tag_element_name: string
+        tag_element_name: str
             The XML tag name of the tag elements. The default is 'node'.
 
         Returns
@@ -411,9 +408,9 @@ class HedDictionary:
 
         Parameters
         ----------
-        attribute_name: string
+        attribute_name: str
             The name of the attribute associated with the element.
-        element_name: string
+        element_name: str
             The name of the XML element tag name. The default is 'node'.
 
         Returns
@@ -429,9 +426,9 @@ class HedDictionary:
 
         Parameters
         ----------
-        element_name: string
+        element_name: str
             The name of the element. The default is 'node'.
-        parent_element: string
+        parent_element: RestrictedElement
             The parent element. The default is 'None'. If a parent element is specified then only the children of the
             parent will be returned with the given 'element_name'. If not specified the root element will be the parent.
 
@@ -454,9 +451,9 @@ class HedDictionary:
         ----------
         tag_elements: list of nodes
             The list to return all child tags from
-        element_name: string
+        element_name: str
             The name of the XML tag elements. The default is 'node'.
-        exclude_take_value_tags: boolean
+        exclude_take_value_tags: bool
             True if to exclude tags that take values. False, if otherwise. The default is True.
 
         Returns
@@ -482,13 +479,13 @@ class HedDictionary:
 
         Parameters
         ----------
-        tag: string
+        tag: str
             A tag.
-        tag_attribute: string
+        tag_attribute: str
             A tag attribute.
         Returns
         -------
-        boolean
+        bool
             True if the tag has the specified attribute. False, if otherwise.
 
         """
@@ -502,11 +499,11 @@ class HedDictionary:
 
         Parameters
         ----------
-        hed_xml_file_path: string
+        hed_xml_file_path: str
             The path to a HED XML file.
         Returns
         -------
-        string
+        str
             The version number of the HED XML file.
 
         """

--- a/hedvalidation/hed/validator/hed_input_reader.py
+++ b/hedvalidation/hed/validator/hed_input_reader.py
@@ -51,14 +51,14 @@ class HedInputReader:
         hed_xml_file: str
             A path to a HED XML file.
         tag_columns: list
-            A list of integers containing the columns that contain the HED tags. The default value is the 2nd column.
+            A list of ints containing the columns that contain the HED tags. The default value is the 2nd column.
         has_column_names: bool
             True if file has column names. The validation will skip over the first line of the file. False, if
             otherwise.
         required_tag_columns: dict
             A dictionary with keys pertaining to the required HED tag columns that correspond to tags that need to be
             prefixed with a parent tag path. For example, prefixed_needed_tag_columns = {3: 'Description',
-            4: 'Label', 5: 'Category'}; The third column contains tags that need Event/Description/ prepended to them,
+            4: 'Label', 5: 'Category'} The third column contains tags that need Event/Description/ prepended to them,
             the fourth column contains tags that need Event/Label/ prepended to them, and the fifth column contains tags
             that needs Event/Category/ prepended to them.
         worksheet_name: str
@@ -107,7 +107,7 @@ class HedInputReader:
 
         Parameters
         ----------
-        hed_xml_file: string
+        hed_xml_file: str
             A path to a HED XML file.
         Returns
         -------
@@ -126,7 +126,7 @@ class HedInputReader:
         Parameters
         ----------
         tag_columns: list
-            A list of integers containing the columns that contain the HED tags.
+            A list of ints containing the columns that contain the HED tags.
         Returns
         -------
         list
@@ -145,10 +145,9 @@ class HedInputReader:
          ----------
          Returns
          -------
-         string
+         list
              The issues that were found.
         """
-        validation_issues = ''
         if isinstance(self._hed_input, list):
             validation_issues = self._validate_hed_strings(self._hed_input)
         elif self._is_file and HedInputReader.hed_input_has_valid_file_extension(self._hed_input):
@@ -164,7 +163,7 @@ class HedInputReader:
          ----------
          Returns
          -------
-         string
+         list
              The issues that were found.
 
          """
@@ -182,7 +181,7 @@ class HedInputReader:
          ----------
          Returns
          -------
-         string
+         list
              The issues that were found.
 
          """
@@ -195,11 +194,11 @@ class HedInputReader:
          ----------
          Returns
          -------
-         string
+         list
              The issues that were found in the text file.
 
          """
-        validation_issues = ''
+        validation_issues = []
         with open(self._hed_input, 'r', encoding='utf-8') as opened_text_file:
             for row_number, text_file_row in enumerate(opened_text_file):
                 if HedInputReader.row_contains_headers(self._has_column_names, row_number):
@@ -218,11 +217,11 @@ class HedInputReader:
          ----------
          Returns
          -------
-         string
+         list
              The issues that were found in a excel worksheet.
 
          """
-        validation_issues = ''
+        validation_issues = []
         opened_worksheet = HedInputReader.open_workbook_worksheet(self._hed_input, worksheet_name=self._worksheet_name)
         number_of_rows = opened_worksheet.nrows
         for row_number in range(number_of_rows):
@@ -240,17 +239,17 @@ class HedInputReader:
 
          Parameters
          ----------
-        validation_issues: string
+        validation_issues: str
             A  string that contains all the issues found in the spreadsheet.
-        row_number: integer
+        row_number: int
             The row number that the issues are associated with.
-        row_hed_string: string
+        row_hed_string: str
             The HED string associated with a row.
-        column_to_hed_tags_dictionary
+        column_to_hed_tags_dictionary: dict
             A dictionary which associates columns with HED tags
          Returns
          -------
-         string
+         list
              The issues with the appended issues found in the particular row.
 
          """
@@ -265,15 +264,15 @@ class HedInputReader:
 
          Parameters
          ----------
-        validation_issues: string
+        validation_issues: str
             A  string that contains all the issues found in the spreadsheet.
-        row_number: integer
+        row_number: int
             The row number that the issues are associated with.
-        row_hed_string: string
+        row_hed_string: str
             The HED string associated with a row.
          Returns
          -------
-         string
+         list
              The issues with the appended issues found in the particular row.
 
          """
@@ -290,15 +289,15 @@ class HedInputReader:
 
          Parameters
          ----------
-        validation_issues: string
+        validation_issues: str
             A  string that contains all the issues found in the spreadsheet.
-        row_number: integer
+        row_number: int
             The row number that the issues are associated with.
-        column_to_hed_tags_dictionary
+        column_to_hed_tags_dictionary: dict
             A dictionary which associates columns with HED tags
          Returns
          -------
-         string
+         list
              The issues with the appended issues found in the particular row column.
 
          """
@@ -316,15 +315,15 @@ class HedInputReader:
 
          Parameters
          ----------
-        column_hed_string: string
+        column_hed_string: str
             The HED string associated with a row column.
          Returns
          -------
-         string
+         list
              The issues associated with a particular row column.
 
          """
-        validation_issues = ''
+        validation_issues = []
         validation_issues += self._tag_validator.run_hed_string_validators(column_hed_string)
         if not validation_issues:
             hed_string_delimiter = HedStringDelimiter(column_hed_string)
@@ -337,28 +336,27 @@ class HedInputReader:
 
          Parameters
          ----------
-         hed_string: string array
-            An array of HED string.
+         hed_strings: list of str
+            An array of HED strings.
          Returns
          -------
-         string
-             The issues associated with the HED strings
+         list
+             The issues associated with the HED strings.
 
          """
         eeg_issues = []
         for i in range(0, len(hed_strings)):
             hed_string = hed_strings[i]
-            validation_issues = self._tag_validator.run_hed_string_validators(hed_string);
+            validation_issues = self._tag_validator.run_hed_string_validators(hed_string)
             if not validation_issues:
-                hed_string_delimiter = HedStringDelimiter(hed_string);
-                validation_issues += self._validate_top_level_in_hed_string(hed_string_delimiter);
-                validation_issues += self._validate_tag_levels_in_hed_string(hed_string_delimiter);
-                validation_issues += self._validate_individual_tags_in_hed_string(hed_string_delimiter);
-                validation_issues += self._validate_groups_in_hed_string(hed_string_delimiter);
-            if validation_issues:
-                validation_issues = "Issue in event " + str(i+1) + ":\n" + validation_issues
-                eeg_issues.append(validation_issues)
-        return eeg_issues;
+                hed_string_delimiter = HedStringDelimiter(hed_string)
+                validation_issues += hed_string_delimiter.get_issues()
+                validation_issues += self._validate_top_level_in_hed_string(hed_string_delimiter)
+                validation_issues += self._validate_tag_levels_in_hed_string(hed_string_delimiter)
+                validation_issues += self._validate_individual_tags_in_hed_string(hed_string_delimiter)
+                validation_issues += self._validate_groups_in_hed_string(hed_string_delimiter)
+            eeg_issues.append(validation_issues)
+        return eeg_issues
 
     def _validate_tag_levels_in_hed_string(self, hed_string_delimiter):
         """Validates the tags at each level in a HED string. This pertains to the top-level, all groups, and nested
@@ -366,15 +364,15 @@ class HedInputReader:
 
          Parameters
          ----------
-         hed_string_delimiter: HedStringDelimiter object
+         hed_string_delimiter: HedStringDelimiter
             A HEDStringDelimiter object.
          Returns
          -------
-         string
+         list
              The issues associated with each level in the HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         tag_groups = hed_string_delimiter.get_tag_groups()
         formatted_tag_groups = hed_string_delimiter.get_formatted_tag_groups()
         original_and_formatted_tag_groups = zip(tag_groups, formatted_tag_groups)
@@ -390,15 +388,15 @@ class HedInputReader:
 
          Parameters
          ----------
-         hed_string_delimiter: HedStringDelimiter object
+         hed_string_delimiter: HedStringDelimiter
             A HEDStringDelimiter object.
          Returns
          -------
-         string
+         list
              The issues associated with the top-level tags in the HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         formatted_top_level_tags = hed_string_delimiter.get_formatted_top_level_tags()
         validation_issues += self._tag_validator.run_top_level_validators(formatted_top_level_tags)
         return validation_issues
@@ -408,15 +406,15 @@ class HedInputReader:
 
          Parameters
          ----------
-         hed_string_delimiter: HedStringDelimiter object
+         hed_string_delimiter: HedStringDelimiter
             A HEDStringDelimiter object.
          Returns
          -------
-         string
+         list
              The issues associated with the groups in the HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         tag_groups = hed_string_delimiter.get_tag_groups()
         tag_group_strings = hed_string_delimiter.get_tag_group_strings()
         tag_groups_with_strings = zip(tag_groups, tag_group_strings)
@@ -429,15 +427,15 @@ class HedInputReader:
 
          Parameters
          ----------
-         hed_string_delimiter: HedStringDelimiter object
+         hed_string_delimiter: HedStringDelimiter
             A HEDStringDelimiter object.
          Returns
          -------
-         string
+         list
              The issues associated with the individual tags in the HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         tag_set = hed_string_delimiter.get_tags()
         formatted_tag_set = hed_string_delimiter.get_formatted_tags()
         original_and_formatted_tags = list(zip(tag_set, formatted_tag_set))
@@ -481,7 +479,7 @@ class HedInputReader:
          ----------
         tag_columns: list
             A list containing the tag column indices.
-         required_tag_columns: dictionary
+         required_tag_columns: dict
             A dictionary containing the required tag columns.
          Returns
          -------
@@ -497,13 +495,13 @@ class HedInputReader:
 
          Parameters
          ----------
-        has_headers: boolean
+        has_headers: bool
             True if file has headers. False, if otherwise.
-         row_number: integer
+         row_number: int
             The row number of the spreadsheet.
          Returns
          -------
-         boolean
+         bool
              True if the row contains the headers. False, if otherwise.
 
          """
@@ -515,17 +513,17 @@ class HedInputReader:
 
          Parameters
          ----------
-         row_number: integer
+         row_number: int
             The row number that the issue is associated with.
          Returns
          -------
-         string
-             The row issue message.
+         list
+             A singleton list containing the row issue message.
 
          """
         if has_headers:
             row_number += 1
-        return error_reporter.report_error_type('row', error_row=row_number)
+        return [error_reporter.report_error_type('row', error_row=row_number)]
 
     @staticmethod
     def generate_column_issue_message(row_number, column_number, has_headers=True):
@@ -533,20 +531,20 @@ class HedInputReader:
 
          Parameters
          ----------
-         row_number: integer
+         row_number: int
             The row number that the issue is associated with.
-         column_number: integer
+         column_number: int
             The column number that the issue is associated with.
          Returns
          -------
-         string
-             The column issue message.
+         list
+             A singleton list containing the column issue message.
 
          """
         if has_headers:
             row_number += 1
         column_number += 1
-        return error_reporter.report_error_type('column', error_row=row_number, error_column=column_number)
+        return [error_reporter.report_error_type('column', error_row=row_number, error_column=column_number)]
 
     @staticmethod
     def file_is_a_text_file(file_extension):
@@ -554,11 +552,11 @@ class HedInputReader:
 
          Parameters
          ----------
-         file_extension: string
+         file_extension: str
             A file extension.
          Returns
          -------
-         boolean
+         bool
              True if the file is a text file. False, if otherwise.
 
          """
@@ -572,7 +570,7 @@ class HedInputReader:
         ----------
         Returns
         -------
-        boolean
+        bool
             True if the hed input has a valid file extension. False, if otherwise.
 
         """
@@ -586,9 +584,9 @@ class HedInputReader:
 
         Parameters
         ----------
-        workbook_path: string
+        workbook_path: str
             The path to an Excel workbook.
-        worksheet_name: string
+        worksheet_name: str
             The name of the workbook worksheet that will be opened. The default will be the first worksheet of the
             workbook.
         Returns
@@ -608,9 +606,9 @@ class HedInputReader:
 
         Parameters
         ----------
-        text_file_row: string
+        text_file_row: str
             The row in the text file that contains the HED tags.
-        column_delimiter: string
+        column_delimiter: str
             A delimiter used to split the columns.
         Returns
         -------
@@ -652,7 +650,7 @@ class HedInputReader:
         ----------
         spreadsheet_row: list
             A list containing the values in the spreadsheet rows.
-        is_worksheet: boolean
+        is_worksheet: bool
             True if the spreadsheet is an Excel worksheet. False if it is a text file.
         Returns
         -------
@@ -682,10 +680,10 @@ class HedInputReader:
 
         Parameters
         ----------
-        row_column_count: integer
+        row_column_count: int
             The number of columns in the row.
         hed_tag_columns: list
-            A list of integers containing the columns that contain the HED tags.
+            A list of ints containing the columns that contain the HED tags.
         Returns
         -------
         list
@@ -699,10 +697,10 @@ class HedInputReader:
 
         Parameters
         ----------
-        required_tag_column_tags: string
+        required_tag_column_tags: str
             A string containing HED tags associated with a required tag column that may need a tag prefix prepended to
             its tags.
-        required_tag_prefix_key: string
+        required_tag_prefix_key: str
             A string dictionary key that corresponds to the required tag prefix that may be prepended to the tags in a
             required tag column if needed.
         Returns
@@ -722,43 +720,43 @@ class HedInputReader:
                     required_tag = required_tag_prefix + required_tag
                 required_tags_with_prefix.append(required_tag)
             return ','.join(required_tags_with_prefix)
-			
+
         if required_tag_prefix and not required_tag_column_tags.lower().startswith(required_tag_prefix.lower()):
             required_tag_column_tags = required_tag_prefix + required_tag_column_tags
 
         return required_tag_column_tags
 
     @staticmethod
-    def subtract_1_from_list_elements(integer_list):
-        """Subtracts 1 from each integer in a list.
+    def subtract_1_from_list_elements(int_list):
+        """Subtracts 1 from each int in a list.
 
         Parameters
         ----------
-        integer_list: list
-            A list of integers.
+        int_list: list
+            A list of ints.
         Returns
         -------
         list
             A list of containing each element subtracted by 1.
 
         """
-        return [x - 1 for x in integer_list]
+        return [x - 1 for x in int_list]
 
     @staticmethod
-    def subtract_1_from_dictionary_keys(integer_key_dictionary):
+    def subtract_1_from_dictionary_keys(int_key_dictionary):
         """Subtracts 1 from each dictionary key.
 
         Parameters
         ----------
-        integer_key_dictionary: dictionary
-            A dictionary with integer keys.
+        int_key_dictionary: dict
+            A dictionary with int keys.
         Returns
         -------
         dictionary
             A dictionary with the keys subtracted by 1.
 
         """
-        return {key - 1: value for key, value in integer_key_dictionary.items()}
+        return {key - 1: value for key, value in int_key_dictionary.items()}
 
     @staticmethod
     def file_path_has_extension(file_path):
@@ -766,11 +764,11 @@ class HedInputReader:
 
         Parameters
         ----------
-        file_path: string
+        file_path: str
              A file path.
         Returns
         -------
-        boolean
+        bool
             Returns True if the file path has an extension. False, if otherwise.
 
         """
@@ -784,7 +782,7 @@ class HedInputReader:
 
         Parameters
         ----------
-        file_path: string
+        file_path: str
              A file path.
         Returns
         -------
@@ -818,7 +816,7 @@ class HedInputReader:
 
         Parameters
         ----------
-        hed_version: string
+        hed_version: str
              The HED version that is in the hed directory.
         Returns
         -------
@@ -880,9 +878,9 @@ class HedInputReader:
 
         Parameters
         ----------
-        first_semantic_version: string
+        first_semantic_version: str
              The first semantic version.
-        second_semantic_version: string
+        second_semantic_version: str
              The second semantic version.
         Returns
         -------

--- a/hedvalidation/hed/validator/tag_validator.py
+++ b/hedvalidation/hed/validator/tag_validator.py
@@ -14,36 +14,38 @@ pluralize.defnoun("hertz", "hertz")
 
 
 class TagValidator:
-    BRACKET_ERROR_TYPE = 'bracket'
-    CHARACTER_ERROR_TYPE = 'character'
-    COMMA_ERROR_TYPE = 'comma'
-    COMMA_VALID_ERROR_TYPE = 'commaValid'
     CAMEL_CASE_EXPRESSION = r'([A-Z-]+\s*[a-z-]*)+'
+    CHARACTER_ERROR_TYPE = 'invalidCharacter'
+    CLOCK_TIME_UNIT_CLASS = 'clockTime'
+    COMMA_ERROR_TYPE = 'commaMissing'
+    COMMA_VALID_ERROR_TYPE = 'extraCommaOrInvalid'
     DEFAULT_UNIT_ATTRIBUTE = 'default'
     DEFAULT_UNITS_FOR_TYPE_ATTRIBUTE = 'defaultUnits'
     DIGIT_EXPRESSION = r'^-?[\d.]+(?:e-?\d+)?$'
-    REQUIRE_CHILD_ERROR_TYPE = 'requireChild'
-    REQUIRED_ERROR_TYPE = 'required'
-    TAG_DICTIONARY_KEY = 'tags'
-    TILDE_ERROR_TYPE = 'tilde'
-    TIME_UNIT_CLASS = 'time'
-    UNITS_ELEMENT = 'units'
-    CLOCK_TIME_UNIT_CLASS = 'clockTime'
-    UNIQUE_ERROR_TYPE = 'unique'
-    DUPLICATE_ERROR_TYPE = 'duplicate'
-    VALID_ERROR_TYPE = 'valid'
+    DUPLICATE_ERROR_TYPE = 'duplicateTag'
     EXTENSION_ALLOWED_ATTRIBUTE = 'extensionAllowed'
+    INVALID_CHARS = '[]{}'
+    PARENTHESES_ERROR_TYPE = 'parentheses'
+    REQUIRE_CHILD_ERROR_TYPE = 'childRequired'
+    REQUIRE_CHILD_TYPE = 'requireChild'
+    REQUIRED_ERROR_TYPE = 'requiredPrefixMissing'
+    REQUIRED_PREFIX_TYPE = 'required'
+    TAG_DICTIONARY_KEY = 'tags'
     TAKES_VALUE_ATTRIBUTE = 'takesValue'
-    IS_NUMERIC_ATTRIBUTE = 'isNumeric'
+    TILDE_ERROR_TYPE = 'tooManyTildes'
+    TIME_UNIT_CLASS = 'time'
+    UNIQUE_ERROR_TYPE = 'multipleUniqueTags'
+    UNIQUE_TAG_TYPE = 'unique'
     UNIT_CLASS_ATTRIBUTE = 'unitClass'
     UNIT_CLASS_UNITS_ELEMENT = 'units'
     UNIT_SYMBOL_TYPE = 'unitSymbol'
-    OPENING_GROUP_BRACKET = '('
-    CLOSING_GROUP_BRACKET = ')'
+    UNITS_ELEMENT = 'units'
+    VALID_ERROR_TYPE = 'invalidTag'
+    OPENING_GROUP_parentheses = '('
+    CLOSING_GROUP_parentheses = ')'
     DOUBLE_QUOTE = '"'
     COMMA = ','
     TILDE = '~'
-    INVALID_CHARS = '[]{}'
     SI_UNIT_MODIFIER_KEY = 'SIUnitModifier'
     SI_UNIT_SYMBOL_MODIFIER_KEY = 'SIUnitSymbolModifier'
 
@@ -52,7 +54,7 @@ class TagValidator:
 
         Parameters
         ----------
-        hed_dictionary: Hed_Dictionary
+        hed_dictionary: HedDictionary
             A Hed_Dictionary object.
 
         Returns
@@ -77,7 +79,7 @@ class TagValidator:
 
          Parameters
          ----------
-         is_error: boolean
+         is_error: bool
             True if the issue is an error, False if it is not.
          Returns
          -------
@@ -97,7 +99,7 @@ class TagValidator:
 
          Returns
          -------
-         integer
+         int
             The issue count
          """
         return self._issue_count
@@ -110,7 +112,7 @@ class TagValidator:
 
          Returns
          -------
-         integer
+         int
             The warning count
          """
         return self._warning_count
@@ -123,7 +125,7 @@ class TagValidator:
 
          Returns
          -------
-         integer
+         int
             The error count
          """
         return self._error_count
@@ -134,21 +136,21 @@ class TagValidator:
 
          Parameters
          ----------
-         original_tag: string
+         original_tag: str
             A original tag.
-         formatted_tag: string
+         formatted_tag: str
             A format tag.
-         previous_original_tag: string
+         previous_original_tag: str
             The previous original tag.
-         previous_formatted_tag: string
+         previous_formatted_tag: str
             The previous format tag.
          Returns
          -------
-         string
+         list
              The validation issues associated with the top-level in the HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         if self._run_semantic_validation:
             validation_issues += self.tag_exist_in_schema(original_tag, formatted_tag, previous_original_tag,
                                                           previous_formatted_tag)
@@ -171,11 +173,11 @@ class TagValidator:
             A string of the tag group.
          Returns
          -------
-         string
+         list
              The validation issues associated with the groups in a HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         validation_issues += self.check_number_of_group_tildes(tag_group, tag_group_string)
         return validation_issues
 
@@ -185,17 +187,17 @@ class TagValidator:
 
          Parameters
          ----------
-         hed_string: string
+         hed_string: str
             A HED string.
          Returns
          -------
-         string
+         list
              The validation issues associated with a HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         validation_issues += self.find_invalid_character_issues(hed_string)
-        validation_issues += self.count_tag_group_brackets(hed_string)
+        validation_issues += self.count_tag_group_parentheses(hed_string)
         validation_issues += self.find_comma_issues_in_hed_string(hed_string)
         return validation_issues
 
@@ -207,15 +209,15 @@ class TagValidator:
          ----------
          original_tag_list: list
             A list containing the original tags.
-        formatted_tag_list: list
+         formatted_tag_list: list
             A list containing formatted tags.
          Returns
          -------
-         string
+         list
              The validation issues associated with each level in a HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         if self._run_semantic_validation:
             validation_issues += self.check_if_multiple_unique_tags_exist(original_tag_list, formatted_tag_list)
         validation_issues += self.check_if_duplicate_tags_exist(original_tag_list, formatted_tag_list)
@@ -230,11 +232,11 @@ class TagValidator:
             A list containing the top-level tags in a HED string.
          Returns
          -------
-         string
+         list
              The validation issues associated with the top-level in a HED string.
 
          """
-        validation_issues = ''
+        validation_issues = []
         if self._check_for_warnings and self._run_semantic_validation:
             validation_issues += self.check_for_required_tags(formatted_top_level_tags)
         return validation_issues
@@ -244,46 +246,46 @@ class TagValidator:
 
         Parameters
         ----------
-        original_tag: string
+        original_tag: str
             The original tag that is used to report the error.
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
-        previous_original_tag: string
+        previous_original_tag: str
             The previous original tag that is used to report the error.
-        previous_formatted_tag: string
+        previous_formatted_tag: str
             The previous tag that is used to do the validation.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
+        validation_issues = []
         is_extension_tag = self.is_extension_allowed_tag(formatted_tag)
         if self._hed_dictionary_dictionaries[TagValidator.TAG_DICTIONARY_KEY].get(formatted_tag) or \
                 self.tag_takes_value(formatted_tag) or formatted_tag == TagValidator.TILDE:
-            return validation_error
+            return validation_issues
 
         if not is_extension_tag and self.tag_takes_value(previous_formatted_tag):
-            validation_error = error_reporter.report_error_type(TagValidator.COMMA_VALID_ERROR_TYPE,
-                                                                tag=original_tag,
-                                                                previous_tag=previous_original_tag)
+            validation_issues += error_reporter.report_error_type(TagValidator.COMMA_VALID_ERROR_TYPE,
+                                                                   tag=original_tag,
+                                                                   previous_tag=previous_original_tag)
             self._increment_issue_count()
         elif not is_extension_tag:
-            validation_error = error_reporter.report_error_type(TagValidator.VALID_ERROR_TYPE, tag=original_tag)
+            validation_issues += error_reporter.report_error_type(TagValidator.VALID_ERROR_TYPE, tag=original_tag)
             self._increment_issue_count()
-        return validation_error
+        return validation_issues
 
     def tag_exists_in_schema(self, formatted_tag):
         """Checks to see if the tag is a valid HED tag.
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        boolean
+        bool
             True if the tag is a valid HED tag. False, if otherwise.
 
         """
@@ -294,27 +296,27 @@ class TagValidator:
 
         Parameters
         ----------
-        original_tag: string
+        original_tag: str
             The original tag that is used to report the warning.
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        string
-            A validation warning string. If no warnings are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_warning = ''
+        validation_issues = []
         tag_names = original_tag.split("/")
         if self.tag_takes_value(formatted_tag):
             tag_names = tag_names[:-1]
         for tag_name in tag_names:
             correct_tag_name = tag_name.capitalize()
             if tag_name != correct_tag_name and not re.search(self.CAMEL_CASE_EXPRESSION, tag_name):
-                validation_warning = warning_reporter.report_warning_type("cap", tag=original_tag)
+                validation_issues += warning_reporter.report_warning_type("capitalization", tag=original_tag)
                 self._increment_issue_count(is_error=False)
                 break
-        return validation_warning
+        return validation_issues
 
     def is_extension_allowed_tag(self, formatted_tag):
         """Checks to see if the tag has the 'extensionAllowed' attribute. It will strip the tag until there are no more
@@ -322,11 +324,11 @@ class TagValidator:
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        boolean
+        bool
             True if the tag has the 'extensionAllowed' attribute. False, if otherwise.
 
         """
@@ -343,11 +345,11 @@ class TagValidator:
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        boolean
+        bool
             True if the tag has the 'takesValue' attribute. False, if otherwise.
 
         """
@@ -360,11 +362,11 @@ class TagValidator:
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        boolean
+        bool
             True if the tag has the 'unitClass' attribute. False, if otherwise.
 
         """
@@ -379,11 +381,11 @@ class TagValidator:
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        string
+        str
             A tag with the a pound sign in place of it's name.
 
         """
@@ -398,17 +400,17 @@ class TagValidator:
 
         Parameters
         ----------
-        original_tag: string
+        original_tag: str
             The original tag that is used to report the error.
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
+        validation_issues = []
         if not self.tag_exists_in_schema(formatted_tag) and self.is_unit_class_tag(formatted_tag):
             tag_unit_classes = self.get_tag_unit_classes(formatted_tag)
             formatted_tag_unit_value = self.get_tag_name(formatted_tag)
@@ -418,40 +420,40 @@ class TagValidator:
                     self._hed_dictionary_dictionaries[self.UNITS_ELEMENT]):
                 if (TagValidator.CLOCK_TIME_UNIT_CLASS in tag_unit_classes
                         and TagValidator.is_clock_face_time(formatted_tag_unit_value)):
-                    return validation_error
+                    return validation_issues
             elif (TagValidator.TIME_UNIT_CLASS in
                   self._hed_dictionary_dictionaries[self.UNITS_ELEMENT]):
                 if (TagValidator.TIME_UNIT_CLASS in tag_unit_classes
                         and TagValidator.is_clock_face_time(formatted_tag_unit_value)):
-                    return validation_error
+                    return validation_issues
             if re.search(TagValidator.DIGIT_EXPRESSION,
                            self.validate_units(original_tag_unit_value,
                                                formatted_tag_unit_value,
                                                tag_unit_class_units)):
                 pass
             else:
-                validation_error = error_reporter.report_error_type('unitClass', tag=original_tag,
-                                                                    unit_class_units=','.join(
-                                                                        sorted(tag_unit_class_units)))
+                validation_issues += error_reporter.report_error_type('unitClassInvalidUnit', tag=original_tag,
+                                                                       unit_class_units=','.join(
+                                                                           sorted(tag_unit_class_units)))
                 self._increment_issue_count()
-        return validation_error
+        return validation_issues
 
     def get_valid_unit_plural(self, unit):
         """
         Parameters
         ----------
-        unit: String
+        unit: str
             unit to generate plural forms
         Returns
         -------
         list
             list of plural units
         """
-        derivativeUnits = [unit]
+        derivative_units = [unit]
         if self._hed_dictionary.has_unit_modifiers and \
                 self._hed_dictionary_dictionaries[self.UNIT_SYMBOL_TYPE].get(unit) is None:
-            derivativeUnits.append(pluralize.plural(unit))
-        return derivativeUnits
+            derivative_units.append(pluralize.plural(unit))
+        return derivative_units
 
     def _strip_off_units_if_valid(self, unit_value, unit, is_unit_symbol):
         """
@@ -460,7 +462,7 @@ class TagValidator:
         ----------
         unit_value      -value of unit
         unit            -what the unit is
-        is_unit_symbol  -unit symbol boolean
+        is_unit_symbol  -unit symbol bool
 
         Returns
         -------
@@ -503,7 +505,7 @@ class TagValidator:
             A list of valid units for this tag
         Returns
         -------
-        string
+        str
             A tag_unit_values with the valid unit removed, if one was present.
             Otherwise, returns tag_unit_values
 
@@ -531,32 +533,32 @@ class TagValidator:
 
         Parameters
         ----------
-        original_tag: string
+        original_tag: str
             The original tag that is used to report the error.
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        string
+        str
             A validation warning string. If no errors are found then an empty string is returned.
 
         """
-        validation_warning = ''
+        validation_issues = []
         if self.is_unit_class_tag(formatted_tag):
             tag_unit_values = self.get_tag_name(formatted_tag)
             if re.search(TagValidator.DIGIT_EXPRESSION, tag_unit_values):
                 default_unit = self.get_unit_class_default_unit(formatted_tag)
-                validation_warning = warning_reporter.report_warning_type('unitClass', tag=original_tag,
-                                                                          default_unit=default_unit)
+                validation_issues += warning_reporter.report_warning_type('unitClassDefaultUsed', tag=original_tag,
+                                                                           default_unit=default_unit)
                 self._increment_issue_count(is_error=False)
-        return validation_warning
+        return validation_issues
 
     def get_tag_name(self, tag):
         """Gets the tag name from the tag path
 
         Parameters
         ----------
-        tag: string
+        tag: str
             A tag which is a path.
         Returns
         -------
@@ -575,7 +577,7 @@ class TagValidator:
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
@@ -596,7 +598,7 @@ class TagValidator:
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
@@ -623,7 +625,7 @@ class TagValidator:
 
         Parameters
         ----------
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
@@ -647,25 +649,6 @@ class TagValidator:
                     first_unit_class]
         return default_unit
 
-    def is_numeric_tag(self, formatted_tag):
-        """Checks to see if the tag has the 'isNumeric' attribute.
-
-        Parameters
-        ----------
-        formatted_tag: string
-            The tag that is used to do the validation.
-        Returns
-        -------
-        boolean
-            True if the tag has the 'isNumeric' attribute. False, if otherwise.
-
-        """
-        last_tag_slash_index = formatted_tag.rfind('/')
-        if last_tag_slash_index != -1:
-            numeric_tag = formatted_tag[:last_tag_slash_index] + '/#'
-            return self._hed_dictionary.tag_has_attribute(numeric_tag, TagValidator.IS_NUMERIC_ATTRIBUTE)
-        return False
-
     def check_number_of_group_tildes(self, tag_group, tag_group_string):
         """Reports a validation error if the tag group has too many tildes.
 
@@ -677,37 +660,37 @@ class TagValidator:
             A string of the tag group.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
+        validation_issues = []
         if tag_group.count('~') > 2:
-            validation_error = error_reporter.report_error_type(TagValidator.TILDE_ERROR_TYPE, tag=tag_group_string)
+            validation_issues += error_reporter.report_error_type(TagValidator.TILDE_ERROR_TYPE, tag=tag_group_string)
             self._increment_issue_count()
-        return validation_error
+        return validation_issues
 
     def check_if_tag_requires_child(self, original_tag, formatted_tag):
         """Reports a validation error if the tag provided has the 'requireChild' attribute.
 
         Parameters
         ----------
-        original_tag: string
+        original_tag: str
             The original tag that is used to report the error.
-        formatted_tag: string
+        formatted_tag: str
             The tag that is used to do the validation.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
-        if self._hed_dictionary_dictionaries[TagValidator.REQUIRE_CHILD_ERROR_TYPE].get(formatted_tag):
-            validation_error = error_reporter.report_error_type(TagValidator.REQUIRE_CHILD_ERROR_TYPE,
-                                                                tag=original_tag)
+        validation_issues = []
+        if self._hed_dictionary_dictionaries[TagValidator.REQUIRE_CHILD_TYPE].get(formatted_tag):
+            validation_issues += error_reporter.report_error_type(TagValidator.REQUIRE_CHILD_ERROR_TYPE,
+                                                                   tag=original_tag)
             self._increment_issue_count()
-        return validation_error
+        return validation_issues
 
     def check_for_required_tags(self, formatted_top_level_tags):
         """Reports a validation error if the required tags aren't present.
@@ -718,20 +701,20 @@ class TagValidator:
             A list containing the top-level tags.
         Returns
         -------
-        string
-            A validation warning string. If no warnings are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_warning = ''
-        required_tag_prefixes = self._hed_dictionary_dictionaries[TagValidator.REQUIRED_ERROR_TYPE]
+        validation_issues = []
+        required_tag_prefixes = self._hed_dictionary_dictionaries[TagValidator.REQUIRED_PREFIX_TYPE]
         for required_tag_prefix in required_tag_prefixes:
             capitalized_required_tag_prefix = \
-                self._hed_dictionary_dictionaries[TagValidator.REQUIRED_ERROR_TYPE][required_tag_prefix]
+                self._hed_dictionary_dictionaries[TagValidator.REQUIRED_PREFIX_TYPE][required_tag_prefix]
             if sum([x.startswith(required_tag_prefix) for x in formatted_top_level_tags]) < 1:
-                validation_warning += warning_reporter.report_warning_type(TagValidator.REQUIRED_ERROR_TYPE,
+                validation_issues += warning_reporter.report_warning_type(TagValidator.REQUIRED_ERROR_TYPE,
                                                                            tag_prefix=capitalized_required_tag_prefix)
                 self._increment_issue_count(is_error=False)
-        return validation_warning
+        return validation_issues
 
     def check_if_multiple_unique_tags_exist(self, original_tag_list, formatted_tag_list):
         """Reports a validation error if two or more tags start with a tag prefix that has the 'unique' attribute.
@@ -744,35 +727,35 @@ class TagValidator:
             A list containing tags that are used to do the validation.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
-        unique_tag_prefixes = self._hed_dictionary_dictionaries[TagValidator.UNIQUE_ERROR_TYPE]
+        validation_issues = []
+        unique_tag_prefixes = self._hed_dictionary_dictionaries[TagValidator.UNIQUE_TAG_TYPE]
         for unique_tag_prefix in unique_tag_prefixes:
-            unique_tag_prefix_boolean_mask = [x.startswith(unique_tag_prefix) for x in formatted_tag_list]
-            if sum(unique_tag_prefix_boolean_mask) > 1:
-                validation_error += error_reporter.report_error_type(
+            unique_tag_prefix_bool_mask = [x.startswith(unique_tag_prefix) for x in formatted_tag_list]
+            if sum(unique_tag_prefix_bool_mask) > 1:
+                validation_issues += error_reporter.report_error_type(
                     TagValidator.UNIQUE_ERROR_TYPE,
-                    tag_prefix=self._hed_dictionary_dictionaries[TagValidator.UNIQUE_ERROR_TYPE][unique_tag_prefix])
+                    tag_prefix=self._hed_dictionary_dictionaries[TagValidator.UNIQUE_TAG_TYPE][unique_tag_prefix])
                 self._increment_issue_count()
-        return validation_error
+        return validation_issues
 
     def tag_has_unique_prefix(self, tag):
         """Checks to see if the tag starts with a prefix.
 
         Parameters
         ----------
-        tag: string
+        tag: str
             A tag.
         Returns
         -------
-        boolean
+        bool
             True if the tag starts with a unique prefix. False if otherwise.
 
         """
-        unique_tag_prefixes = self._hed_dictionary_dictionaries[TagValidator.UNIQUE_ERROR_TYPE]
+        unique_tag_prefixes = self._hed_dictionary_dictionaries[TagValidator.UNIQUE_TAG_TYPE]
         for unique_tag_prefix in unique_tag_prefixes:
             if tag.lower().startswith(unique_tag_prefix):
                 return True
@@ -789,11 +772,11 @@ class TagValidator:
             A list containing tags that are used to do the validation.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
+        validation_issues = []
         duplicate_indices = set([])
         for tag_index, tag in enumerate(formatted_tag_list):
             all_indices = range(len(formatted_tag_list))
@@ -805,19 +788,19 @@ class TagValidator:
                         tag_index not in duplicate_indices and duplicate_index not in duplicate_indices:
                     duplicate_indices.add(tag_index)
                     duplicate_indices.add(duplicate_index)
-                    validation_error += error_reporter.report_error_type(TagValidator.DUPLICATE_ERROR_TYPE,
-                                                                         tag=original_tag_list[tag_index])
+                    validation_issues += error_reporter.report_error_type(TagValidator.DUPLICATE_ERROR_TYPE,
+                                                                           tag=original_tag_list[tag_index])
                     self._increment_issue_count()
-        return validation_error
+        return validation_issues
 
     def get_tag_slash_indices(self, tag, slash='/'):
         """Gets all of the indices in a tag that are slashes.
 
         Parameters
         ----------
-        tag: string
+        tag: str
             A tag.
-        slash: string
+        slash: str
             The slash character. By default it is a forward slash.
         Returns
         -------
@@ -832,13 +815,13 @@ class TagValidator:
 
         Parameters
         ----------
-        tag: string
+        tag: str
             A tag.
         end_index: int
             A index for the tag substring to end.
         Returns
         -------
-        string
+        str
             A tag substring.
 
         """
@@ -851,18 +834,18 @@ class TagValidator:
 
         Parameters
         ----------
-        hed_string: string
+        hed_string: str
             A hed string.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
         last_non_empty_valid_character = ''
         last_non_empty_valid_index = 0
         current_tag = ''
-        issues = ''
+        issues = []
 
         for i in range(len(hed_string)):
             current_character = hed_string[i]
@@ -872,28 +855,28 @@ class TagValidator:
             if TagValidator.character_is_delimiter(current_character):
                 if current_tag.strip() == current_character:
                     issues += error_reporter.report_error_type('extraDelimiter',
-                                                               character=current_character,
-                                                               index=i,
-                                                               hed_string=hed_string)
+                                                                character=current_character,
+                                                                index=i,
+                                                                hed_string=hed_string)
                     current_tag = ''
                     continue
                 current_tag = ''
-            elif current_character == self.OPENING_GROUP_BRACKET:
-                if current_tag.strip() == self.OPENING_GROUP_BRACKET:
+            elif current_character == self.OPENING_GROUP_parentheses:
+                if current_tag.strip() == self.OPENING_GROUP_parentheses:
                     current_tag = ''
                 else:
-                    issues += error_reporter.report_error_type('valid', tag=current_tag)
-            elif TagValidator.comma_is_missing_after_closing_bracket(last_non_empty_valid_character,
+                    issues += error_reporter.report_error_type('invalidTag', tag=current_tag)
+            elif TagValidator.comma_is_missing_after_closing_parentheses(last_non_empty_valid_character,
                                                                      current_character):
-                issues += error_reporter.report_error_type('comma', tag=current_tag)
+                issues += error_reporter.report_error_type('commaMissing', tag=current_tag)
                 break
             last_non_empty_valid_character = current_character
             last_non_empty_valid_index = i
         if TagValidator.character_is_delimiter(last_non_empty_valid_character):
             issues += error_reporter.report_error_type('extraDelimiter',
-                                                       character=last_non_empty_valid_character,
-                                                       index=last_non_empty_valid_index,
-                                                       hed_string=hed_string)
+                                                        character=last_non_empty_valid_character,
+                                                        index=last_non_empty_valid_index,
+                                                        hed_string=hed_string)
         return issues
 
     def skip_iterations(self, iterator, start, end):
@@ -903,9 +886,9 @@ class TagValidator:
         ----------
         iterator: iterator
             A iterator object.
-        start: integer
+        start: int
             The start position in the iterator to start skipping.
-        end: integer
+        end: int
             The end position in the iterator to stop skipping.
         Returns
         -------
@@ -919,12 +902,33 @@ class TagValidator:
         return iterator
 
     @staticmethod
+    def report_invalid_character_error(character, index, hed_string):
+        """Reports a error that is related to an invalid character.
+
+        Parameters
+        ----------
+        character: str
+            The invalid character.
+        index: int
+            The index of the invalid character in the HED string.
+        hed_string: str
+            The HED string that caused the error.
+        Returns
+        -------
+        list of dict
+            A singleton list with a dictionary representing the error.
+
+        """
+        return error_reporter.report_error_type(TagValidator.CHARACTER_ERROR_TYPE, character=character, index=index,
+                                                hed_string=hed_string)
+
+    @staticmethod
     def report_missing_comma_error(error_tag):
         """Reports a error that is related with a missing comma.
 
         Parameters
         ----------
-        error_tag: string
+        error_tag: str
             The tag that caused the error.
         Returns
         -------
@@ -936,62 +940,45 @@ class TagValidator:
         return error_reporter.report_error_type(TagValidator.COMMA_ERROR_TYPE, tag=error_tag)
 
     @staticmethod
-    def report_invalid_character_error(error_tag):
-        """Reports a error that is related with an invalid character
-
-        Parameters
-        ----------
-        error_tag: string
-            The tag that caused the error.
-        Returns
-        -------
-        string
-            The error message associated with a missing comma.
-
-        """
-        error_tag = error_tag.strip()
-        return error_reporter.report_error_type(TagValidator.CHARACTER_ERROR_TYPE, tag=error_tag)
-
-    @staticmethod
-    def comma_is_missing_before_opening_bracket(last_non_empty_character, current_character):
-        """Checks to see if a comma is missing before a opening bracket in a HED string. This is a helper function for
+    def comma_is_missing_before_opening_parentheses(last_non_empty_character, current_character):
+        """Checks to see if a comma is missing before a opening parentheses in a HED string. This is a helper function for
            the find_missing_commas_in_hed_string function.
 
         Parameters
         ----------
         last_non_empty_character: character
             The last non-empty string in the HED string.
-        current_character: string
+        current_character: str
             The current character in the HED string.
         Returns
         -------
-        boolean
-            True if a comma is missing before a opening bracket. False, if otherwise.
+        bool
+            True if a comma is missing before a opening parentheses. False, if otherwise.
 
         """
         return last_non_empty_character and not TagValidator.character_is_delimiter(last_non_empty_character) and \
-               current_character == TagValidator.OPENING_GROUP_BRACKET
+               current_character == TagValidator.OPENING_GROUP_parentheses
 
     @staticmethod
-    def comma_is_missing_after_closing_bracket(last_non_empty_character, current_character):
-        """Checks to see if a comma is missing after a closing bracket in a HED string. This is a helper function for
+    def comma_is_missing_after_closing_parentheses(last_non_empty_character, current_character):
+        """Checks to see if a comma is missing after a closing parentheses in a HED string. This is a helper function for
            the find_missing_commas_in_hed_string function.
 
         Parameters
         ----------
         last_non_empty_character: character
             The last non-empty string in the HED string.
-        current_character: string
+        current_character: str
             The current character in the HED string.
         Returns
         -------
-        boolean
-            True if a comma is missing after a closing bracket. False, if otherwise.
+        bool
+            True if a comma is missing after a closing parentheses. False, if otherwise.
 
         """
-        return last_non_empty_character == TagValidator.CLOSING_GROUP_BRACKET and not \
+        return last_non_empty_character == TagValidator.CLOSING_GROUP_parentheses and not \
             (TagValidator.character_is_delimiter(current_character)
-             or current_character == TagValidator.CLOSING_GROUP_BRACKET)
+             or current_character == TagValidator.CLOSING_GROUP_parentheses)
 
     @staticmethod
     def character_is_delimiter(character):
@@ -1016,45 +1003,45 @@ class TagValidator:
 
         Parameters
         ----------
-        hed_string: string
+        hed_string: str
             A hed string.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
-        for character in hed_string:
+        validation_issues = []
+        for index, character in enumerate(hed_string):
             if character in TagValidator.INVALID_CHARS:
-                validation_error = TagValidator.report_invalid_character_error(character)
+                validation_issues += TagValidator.report_invalid_character_error(character, index, hed_string)
                 self._increment_issue_count()
 
-        return validation_error
+        return validation_issues
 
-    def count_tag_group_brackets(self, hed_string):
+    def count_tag_group_parentheses(self, hed_string):
         """Reports a validation error if there are an unequal number of opening or closing parentheses. This is the
          first check before the tags are parsed.
 
         Parameters
         ----------
-        hed_string: string
+        hed_string: str
             A hed string.
         Returns
         -------
-        string
-            A validation error string. If no errors are found then an empty string is returned.
+        list
+            A validation issues list. If no issues are found then an empty list is returned.
 
         """
-        validation_error = ''
-        number_of_opening_brackets = hed_string.count('(')
-        number_of_closing_brackets = hed_string.count(')')
-        if number_of_opening_brackets != number_of_closing_brackets:
-            validation_error = error_reporter.report_error_type(TagValidator.BRACKET_ERROR_TYPE,
-                                                                opening_bracket_count=number_of_opening_brackets,
-                                                                closing_bracket_count=number_of_closing_brackets)
+        validation_issues = []
+        number_of_opening_parentheses = hed_string.count('(')
+        number_of_closing_parentheses = hed_string.count(')')
+        if number_of_opening_parentheses != number_of_closing_parentheses:
+            validation_issues += error_reporter.report_error_type(TagValidator.PARENTHESES_ERROR_TYPE,
+                                                                   opening_parentheses_count=number_of_opening_parentheses,
+                                                                   closing_parentheses_count=number_of_closing_parentheses)
             self._increment_issue_count()
-        return validation_error
+        return validation_issues
 
     @staticmethod
     def is_clock_face_time(time_string):
@@ -1062,7 +1049,7 @@ class TagValidator:
 
         Parameters
         ----------
-        time_string: string
+        time_string: str
             A time string.
         Returns
         -------

--- a/hedvalidation/hed/validator/warning_reporter.py
+++ b/hedvalidation/hed/validator/warning_reporter.py
@@ -1,7 +1,7 @@
-'''
+"""
 This module is used to report warnings found in the validation.
 
-'''
+"""
 
 
 def report_warning_type(warning_type, tag='', default_unit='', tag_prefix=''):
@@ -16,16 +16,21 @@ def report_warning_type(warning_type, tag='', default_unit='', tag_prefix=''):
     default_unit: string
         The default unit class unit associated with the warning.
     tag_prefix: string
-        The tag prefix that generated the error.
+        The tag prefix that generated the warning.
     Returns
     -------
-    string
-        A warning message related to a particular type of warning.
+    list of dict
+        A singleton list containing a dictionary with the warning type and warning message related to a particular type
+        of warning.
 
     """
     warning_types = {
-        'cap': '\tWARNING: First word not capitalized or camel case - "%s"\n' % tag,
-        'required': '\tWARNING: Tag with prefix \"%s\" is required\n' % tag_prefix,
-        'unitClass': '\tWARNING: No unit specified. Using "%s" as the default - "%s"\n' % (default_unit, tag)
+        'capitalization': '\tWARNING: First word not capitalized or camel case - "%s"\n' % tag,
+        'requiredPrefixMissing': '\tWARNING: Tag with prefix "%s" is required\n' % tag_prefix,
+        'unitClassDefaultUsed': '\tWARNING: No unit specified. Using "%s" as the default - "%s"\n' % (default_unit, tag)
     }
-    return warning_types.get(warning_type, None)
+    default_warning_message = 'WARNING: Unknown warning'
+    warning_message = warning_types.get(warning_type, default_warning_message)
+
+    warning_object = {'code': warning_type, 'message': warning_message}
+    return [warning_object]


### PR DESCRIPTION
This commit fixes #25 by converting the error reporting from concatenated strings to lists of dictionaries, which contain the error/warning code and the message.

The translated tests have been fixed to work with this, as well as to fix other problems.

I have also rewritten most of the docstring type information to reflect the actual Python type names.