### PR TITLE
Implement datetime code

### DIFF
--- a/hedvalidation/hed/validator/tag_validator.py
+++ b/hedvalidation/hed/validator/tag_validator.py
@@ -3,6 +3,7 @@ This module is used to validate the HED tags as strings.
 
 """
 
+import datetime
 import re
 import time
 import inflect
@@ -19,6 +20,7 @@ class TagValidator:
     CLOCK_TIME_UNIT_CLASS = 'clockTime'
     COMMA_ERROR_TYPE = 'commaMissing'
     COMMA_VALID_ERROR_TYPE = 'extraCommaOrInvalid'
+    DATE_TIME_UNIT_CLASS = 'dateTime'
     DEFAULT_UNIT_ATTRIBUTE = 'default'
     DEFAULT_UNITS_FOR_TYPE_ATTRIBUTE = 'defaultUnits'
     DIGIT_EXPRESSION = r'^-?[\d.]+(?:e-?\d+)?$'
@@ -416,6 +418,11 @@ class TagValidator:
             formatted_tag_unit_value = self.get_tag_name(formatted_tag)
             original_tag_unit_value = self.get_tag_name(original_tag)
             tag_unit_class_units = tuple(self.get_tag_unit_class_units(formatted_tag))
+            if (TagValidator.DATE_TIME_UNIT_CLASS in
+                    self._hed_dictionary_dictionaries[self.UNITS_ELEMENT]):
+                if (TagValidator.DATE_TIME_UNIT_CLASS in tag_unit_classes
+                        and TagValidator.is_clock_face_time(formatted_tag_unit_value)):
+                    return validation_issues
             if (TagValidator.CLOCK_TIME_UNIT_CLASS in
                     self._hed_dictionary_dictionaries[self.UNITS_ELEMENT]):
                 if (TagValidator.CLOCK_TIME_UNIT_CLASS in tag_unit_classes
@@ -1007,7 +1014,7 @@ class TagValidator:
 
     @staticmethod
     def is_clock_face_time(time_string):
-        """Checks to see if the specified string is valid HH:MM time string.
+        """Checks to see if the specified string is a valid HH:MM time string.
 
         Parameters
         ----------
@@ -1026,6 +1033,26 @@ class TagValidator:
                 time.strptime(time_string, '%H:%M')
             except ValueError:
                 return False
+        return True
+
+    @staticmethod
+    def is_date_time(date_time_string):
+        """Checks to see if the specified string is a valid ISO 8601 datetime string.
+
+        Parameters
+        ----------
+        date_time_string: str
+            A datetime string.
+        Returns
+        -------
+        string
+            True if the datetime string is valid. False, if otherwise.
+
+        """
+        try:
+            datetime.datetime.fromisoformat(date_time_string)
+        except ValueError:
+            return False
         return True
 
 

--- a/hedvalidation/tests/test_tag_validator_util.py
+++ b/hedvalidation/tests/test_tag_validator_util.py
@@ -1,5 +1,6 @@
 import unittest
 
+from hed.validator.tag_validator import TagValidator
 from tests.test_tag_validator import TestHed
 
 
@@ -30,6 +31,52 @@ class StringUtilityFunctions(TestHed):
         self.assertEqual(name1, 'Something')
         self.assertEqual(name2, 'Left')
         self.assertEqual(no_slash_name, 'Participant')
+
+    def test_clock_face_times(self):
+        valid_test_strings = {
+            'validPM': '23:52',
+            'validMidnight': '00:55',
+            'validHour': '11:00',
+            'validSingleDigitHour': '08:30',
+            'validSeconds': '19:33:47',
+        }
+        invalid_test_strings = {
+            'invalidDate': '8/8/2019',
+            'invalidHour': '25:11',
+            'invalidSingleDigitHour': '8:30',
+            'invalidMinute': '12:65',
+            'invalidSecond': '15:45:82',
+            'invalidString': 'not a time',
+        }
+        for string in valid_test_strings.values():
+            result = TagValidator.is_clock_face_time(string)
+            self.assertEqual(result, True, string)
+        for string in invalid_test_strings.values():
+            result = TagValidator.is_clock_face_time(string)
+            self.assertEqual(result, False, string)
+
+    def test_date_times(self):
+        valid_test_strings = {
+            'validPM': '2000-01-01T23:52:00',
+            'validMidnight': '2000-01-01T00:55:00',
+            'validHour': '2000-01-01T11:00:00',
+            'validSingleDigitHour': '2000-01-01T08:30:00',
+            'validSeconds': '2000-01-01T19:33:47',
+        }
+        invalid_test_strings = {
+            'invalidDate': '8/8/2019',
+            'invalidHour': '2000-01-01T25:11',
+            'invalidSingleDigitHour': '2000-01-01T8:30',
+            'invalidMinute': '2000-01-01T12:65',
+            'invalidSecond': '2000-01-01T15:45:82',
+            'invalidString': 'not a time',
+        }
+        for string in valid_test_strings.values():
+            result = TagValidator.is_date_time(string)
+            self.assertEqual(result, True, string)
+        for string in invalid_test_strings.values():
+            result = TagValidator.is_date_time(string)
+            self.assertEqual(result, False, string)
 
 
 class TestSchemaUtilityFunctions(TestHed):
@@ -140,12 +187,12 @@ class TestSchemaUtilityFunctions(TestHed):
             validate_units(volume_string, volume_string, volume_units)
         stripped_prefixed_volume_string = self.semantic_tag_validator. \
             validate_units(prefixed_volume_string, prefixed_volume_string, volume_units)
-        # stripped_invalid_volume_string = self.semantic_tag_validator. \
-        #    validate_units(invalid_volume_string, invalid_volume_string, volume_units)
+        stripped_invalid_volume_string = self.semantic_tag_validator. \
+            validate_units(invalid_volume_string, invalid_volume_string, volume_units)
         self.assertEqual(stripped_dollars_string, '25.99')
         self.assertEqual(stripped_volume_string, '100')
         self.assertEqual(stripped_prefixed_volume_string, '100')
-        self.assertEqual(invalid_volume_string, '200 cm')
+        self.assertEqual(stripped_invalid_volume_string, '200 cm')
 
     def test_determine_allows_extensions(self):
         extension_tag1 = 'item/object/vehicle/boat'


### PR DESCRIPTION
This branch implements datetime validation using ISO 8601 datetime strings. The validation is implemented by attempting to parse the string using the `datetime.fromisoformat()` function from the `datetime` standard library module. This function was added in Python 3.7, and thus that is now the minimum version supported.

Tests were added for the new code and for `clockTime` validation, which was accidentally left out of the previous JavaScript test port. An unrelated existing assertion which was commented out to avoid that test failing was uncommented, as the assertion now passes.

Fixes #60