### PR TITLE
Fix crash if more than one ':' on version line in mediawiki.  

### DIFF
--- a/hedtools/hed/schematools/parsetag.py
+++ b/hedtools/hed/schematools/parsetag.py
@@ -106,7 +106,10 @@ def get_tag_attributes(tag_line):
     attributes = re.compile(attributes_expression)
     match = attributes.search(tag_line)
     if match:
-        return [x.strip() for x in re.sub('[{}]', '', match.group()).split(',')]
+        attributes_split = [x.strip() for x in re.sub('[{}]', '', match.group()).split(',')]
+        # Filter out attributes with spaces.
+        final_attributes = [a for a in attributes_split if " " not in a]
+        return final_attributes
     else:
         return ''
 

--- a/hedtools/hed/schematools/parsewiki.py
+++ b/hedtools/hed/schematools/parsewiki.py
@@ -230,7 +230,7 @@ def get_hed_attributes(version_line):
     final_attributes = {}
     attribute_pairs = version_line.split(',')
     for pair in attribute_pairs:
-        if ':' not in pair:
+        if pair.count(':') != 1:
             continue
         key, value = pair.split(':')
         key = key.strip()


### PR DESCRIPTION
Fix crash if spaces found between curly brackets in mediawiki