### PR TITLE
Add warning for a column not defined in json - this will produce lots…

### DIFF
--- a/hedtools/hed/errors/error_messages.py
+++ b/hedtools/hed/errors/error_messages.py
@@ -115,6 +115,11 @@ def val_error_missing_column(missing_column_name):
     return f"Required column '{missing_column_name}' not specified or found in file.", {}
 
 
+@hed_error(ValidationErrors.HED_UNKNOWN_COLUMN, default_severity=ErrorSeverity.WARNING)
+def val_error_extra_column(extra_column_name):
+    return f"Column named '{extra_column_name}' found in file, but not specified as a tag column or identified in sidecars.", {}
+
+
 @hed_tag_error(ValidationErrors.HED_UNKNOWN_PREFIX)
 def val_error_unknown_prefix(tag, unknown_prefix, known_prefixes):
     return f"Tag '{tag} has unknown prefix '{unknown_prefix}'.  Valid prefixes: {known_prefixes}", {}

--- a/hedtools/hed/errors/error_types.py
+++ b/hedtools/hed/errors/error_types.py
@@ -47,6 +47,7 @@ class ValidationErrors:
     # HED_VERSION_WARNING
 
     HED_MISSING_COLUMN = "HED_MISSING_COLUMN"
+    HED_UNKNOWN_COLUMN = "HED_UNKNOWN_COLUMN"
     HED_UNKNOWN_PREFIX = "HED_UNKNOWN_PREFIX"
 
     # Below here shows what the given error maps to

--- a/hedtools/hed/errors/exceptions.py
+++ b/hedtools/hed/errors/exceptions.py
@@ -18,18 +18,21 @@ class HedExceptions:
     HED_END_INVALID = 'hedEndMissing'
     INVALID_SECTION_SEPARATOR = 'invalidSectionSeparator'
 
+    # This issue will contain a list of lines with issues.
+    HED_SCHEMA_WIKI_WARNINGS = 'HED_SCHEMA_WIKI_WARNINGS'
     HED_SCHEMA_NODE_NAME_INVALID = 'HED_SCHEMA_NODE_NAME_INVALID'
-    HED_WIKI_DELIMITERS_INVALID = 'HED_WIKI_DELIMITERS_INVALID'
 
     SCHEMA_DUPLICATE_PREFIX = 'schemaDuplicatePrefix'
 
 
 class HedFileError(Exception):
     """Exception raised when a file cannot be parsed due to being malformed, file IO, etc."""
-    def __init__(self, error_type, message, filename):
+    def __init__(self, error_type, message, filename, issues=None):
         self.error_type = error_type
         self.message = message
         self.filename = filename
+        # only filled in when this lists multiple errors, such as the HED_SCHEMA_WIKI_WARNINGS
+        self.issues = issues
 
     def format_error_message(self, include_tabbing=True, return_string_only=False,
                              name=None):
@@ -71,7 +74,6 @@ class HedFileError(Exception):
             HedExceptions.HED_END_INVALID: f"{error_prefix}{self.message}.  '{filename}'",
             HedExceptions.INVALID_SECTION_SEPARATOR: f"{error_prefix}{self.message}.  '{filename}'",
             HedExceptions.HED_SCHEMA_NODE_NAME_INVALID: f"{error_prefix}{self.message}.  '{filename}'",
-            HedExceptions.HED_WIKI_DELIMITERS_INVALID: f"{error_prefix}{self.message}.  '{filename}'"
         }
         default_error_message = f'{error_prefix}Internal Error'
         error_message = error_types.get(error_type, default_error_message)

--- a/hedtools/hed/models/hed_string.py
+++ b/hedtools/hed/models/hed_string.py
@@ -54,6 +54,7 @@ class HedString(HedGroup):
         combined_hed_string_obj: HedString
             The combined hed string, containing all tags and delimiters from the list
         """
+        hed_string_obj_list = [hed_string_obj for hed_string_obj in hed_string_obj_list if hed_string_obj is not None]
         new_hed_string_obj = HedString("")
         for hed_string_obj in hed_string_obj_list:
             new_hed_string_obj._children += hed_string_obj._children

--- a/hedtools/hed/models/model_constants.py
+++ b/hedtools/hed/models/model_constants.py
@@ -1,6 +1,7 @@
 COLUMN_TO_HED_TAGS = "column_to_hed_tags"
 ROW_HED_STRING = "HED"
 COLUMN_ISSUES = "column_issues"
+ROW_ISSUES = "row_issues"
 
 
 class DefTagNames:

--- a/hedtools/hed/schema/hed_schema.py
+++ b/hedtools/hed/schema/hed_schema.py
@@ -34,7 +34,6 @@ class HedSchema:
         self.prologue = ""
         self.epilogue = ""
 
-        self.issues = []
         self._is_hed3_schema = None
         # This is the specified library prefix - tags will be {library_prefix}:{tag_name}
         self._library_prefix = ""

--- a/hedtools/hed/schema/schema_validation_util.py
+++ b/hedtools/hed/schema/schema_validation_util.py
@@ -50,5 +50,3 @@ def validate_attributes(attrib_dict, filename):
         raise HedFileError(HedExceptions.BAD_HED_SEMANTIC_VERSION, "No version attribute found in header",
                            filename=filename)
 
-    # Placeholder for future warnings
-    return []

--- a/hedtools/tests/data/invalid_wiki_schemas/empty_node.mediawiki
+++ b/hedtools/tests/data/invalid_wiki_schemas/empty_node.mediawiki
@@ -6,7 +6,6 @@ This schema is the first official release that includes an xsd and requires unit
 !# start schema
 
 '''Event''' <nowiki>{suggestedTag=Task-property}[Something that happens at a given time and (typically) place. Elements of this tag subtree designate the general category in which an event falls.]</nowiki>
- Sensory-event <nowiki>{suggestedTag=Task-event-role, suggestedTag=Attribute/Sensory}[Something perceivable by the participant. An event meant to be an experimental stimulus should include the tag Task-property/Task-event-role/Experimental-stimulus.]</nowiki>
 *<nowiki><nowiki>{suggestedTag=Task-event-role, suggestedTag=Attribute/Sensory}[Something perceivable by the participant. An event meant to be an experimental stimulus should include the tag Task-property/Task-event-role/Experimental-stimulus.]</nowiki>
 * Agent-action <nowiki>{suggestedTag=Task-event-role, suggestedTag=Agent}[Any action engaged in by an agent (see the Agent subtree for agent categories). A participant response to an experiment stimulus should include the tag Agent-property/Agent-task-role/Experiment-participant.]</nowiki>
 * Data-feature <nowiki>{suggestedTag=Data-property}[An event marking the occurrence of a data feature such as an interictal spike or alpha burst that is often added post hoc to the data record.]</nowiki>

--- a/hedtools/tests/data/validator_tests/bids_events_bad_category_key.tsv
+++ b/hedtools/tests/data/validator_tests/bids_events_bad_category_key.tsv
@@ -1,5 +1,5 @@
 	onset	duration	event-type	sample	stage	trial	bci_prediction	bci_prediction_valid	n_repeated	latency
-0	15.038933333333	3	cue	75195.0	1	1	right	1	2	-4.2
+0	15.038933333333	3	invalidkey	75195.0	1	1	right	1	2	-4.2
 1	18.038933333333002	0	go	90195.0	1	1	right	1	2	-4.2
 2	18.1556	0	right-raised	90778.0	1	1	right	1	2	-4.2
 3	18.2236	0	right-raised-nomatch	91118.0	1	1	right	1	2	-4.2

--- a/hedtools/tests/data/validator_tests/bids_events_bad_column_name.tsv
+++ b/hedtools/tests/data/validator_tests/bids_events_bad_column_name.tsv
@@ -1,5 +1,5 @@
-	onset	duration	event-type	sample	stage	trial	bci_prediction	bci_prediction_valid	n_repeated	latency
-0	15.038933333333	3	cue	75195.0	1	1	right	1	2	-4.2
+	onset	duration	event_type	sample	stage	trial	bci_prediction	bci_prediction_valid	n_repeated	latency
+0	15.038933333333	3	invalidkey	75195.0	1	1	right	1	2	-4.2
 1	18.038933333333002	0	go	90195.0	1	1	right	1	2	-4.2
 2	18.1556	0	right-raised	90778.0	1	1	right	1	2	-4.2
 3	18.2236	0	right-raised-nomatch	91118.0	1	1	right	1	2	-4.2

--- a/hedtools/tests/models/test_events_file_input.py
+++ b/hedtools/tests/models/test_events_file_input.py
@@ -1,0 +1,60 @@
+import unittest
+import os
+import io
+
+from hed import HedInput, Sidecar, EventsInput
+import shutil
+from hed import schema
+from hed import HedValidator
+
+class Test(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.base_output_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/tests_output/")
+        os.makedirs(cls.base_output_folder, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.base_output_folder)
+
+    def test_missing_column_name_issue(self):
+        schema_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                  '../data/validator_tests/bids_schema.mediawiki')
+        events_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   '../data/validator_tests/bids_events_bad_column_name.tsv')
+
+        hed_schema = schema.load_schema(schema_path)
+        json_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/validator_tests/bids_events.json")
+        validator = HedValidator(hed_schema=hed_schema)
+        sidecar = Sidecar(json_path)
+        issues = sidecar.validate_entries(validator)
+        self.assertEqual(len(issues), 0)
+        input_file = EventsInput(events_path, sidecars=sidecar)
+
+        validation_issues = input_file.validate_file_sidecars(validator)
+        self.assertEqual(len(validation_issues), 0)
+        validation_issues = input_file.validate_file(validator)
+        self.assertEqual(len(validation_issues), 1)
+
+    def test_expand_column_issues(self):
+        schema_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                  '../data/validator_tests/bids_schema.mediawiki')
+        events_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   '../data/validator_tests/bids_events_bad_category_key.tsv')
+
+        hed_schema = schema.load_schema(schema_path)
+        json_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/validator_tests/bids_events.json")
+        validator = HedValidator(hed_schema=hed_schema)
+        sidecar = Sidecar(json_path)
+        issues = sidecar.validate_entries(validator)
+        self.assertEqual(len(issues), 0)
+        input_file = EventsInput(events_path, sidecars=sidecar)
+
+        validation_issues = input_file.validate_file_sidecars(validator)
+        self.assertEqual(len(validation_issues), 0)
+        validation_issues = input_file.validate_file(validator)
+        self.assertEqual(len(validation_issues), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hedtools/tests/models/test_hed_file_input.py
+++ b/hedtools/tests/models/test_hed_file_input.py
@@ -132,7 +132,7 @@ class Test(unittest.TestCase):
                                                                           input_file_2.iter_dataframe()):
             self.assertEqual(row_number, row_number2,
                              f"EventsInput should have row {row_number} equal to {row_number2} after reset")
-            self.assertTrue(len(column_dict) == 4,
+            self.assertTrue(len(column_dict) == 5,
                             f"The column dictionary for row {row_number} should have the right length")
             self.assertTrue(len(column_dict2) == 11,
                             f"The reset column dictionary for row {row_number2} should have the right length")

--- a/hedtools/tests/schema/test_schema_wiki_fatal_errors.py
+++ b/hedtools/tests/schema/test_schema_wiki_fatal_errors.py
@@ -22,15 +22,23 @@ class TestHedSchema(unittest.TestCase):
             "HED_header_missing_version.mediawiki": HedExceptions.BAD_HED_SEMANTIC_VERSION,
             "HED_header_bad_library.mediawiki": HedExceptions.BAD_HED_LIBRARY_NAME,
             "HED_schema_out_of_order.mediawiki": HedExceptions.SCHEMA_START_MISSING,
-            "empty_node.mediawiki": HedExceptions.HED_SCHEMA_NODE_NAME_INVALID,
-            "malformed_line.mediawiki": HedExceptions.HED_SCHEMA_NODE_NAME_INVALID,
-            "malformed_line2.mediawiki": HedExceptions.HED_WIKI_DELIMITERS_INVALID,
-            "malformed_line3.mediawiki": HedExceptions.HED_WIKI_DELIMITERS_INVALID,
-            "malformed_line4.mediawiki": HedExceptions.HED_WIKI_DELIMITERS_INVALID,
-            "malformed_line5.mediawiki": HedExceptions.HED_WIKI_DELIMITERS_INVALID,
+            "empty_node.mediawiki": HedExceptions.HED_SCHEMA_WIKI_WARNINGS,
+            "malformed_line.mediawiki": HedExceptions.HED_SCHEMA_WIKI_WARNINGS,
+            "malformed_line2.mediawiki": HedExceptions.HED_SCHEMA_WIKI_WARNINGS,
+            "malformed_line3.mediawiki": HedExceptions.HED_SCHEMA_WIKI_WARNINGS,
+            "malformed_line4.mediawiki": HedExceptions.HED_SCHEMA_WIKI_WARNINGS,
+            "malformed_line5.mediawiki": HedExceptions.HED_SCHEMA_WIKI_WARNINGS,
             "empty_node.xml": HedExceptions.HED_SCHEMA_NODE_NAME_INVALID
         }
 
+        cls.expected_count = {
+            "empty_node.mediawiki": 1,
+            "malformed_line.mediawiki": 1,
+            "malformed_line2.mediawiki": 1,
+            "malformed_line3.mediawiki": 1,
+            "malformed_line4.mediawiki": 1,
+            "malformed_line5.mediawiki": 1,
+        }
     def test_invalid_schema(self):
         for filename, error in self.files_and_errors.items():
             full_filename = self.full_base_folder + filename
@@ -41,4 +49,6 @@ class TestHedSchema(unittest.TestCase):
                 self.assertFalse(True)
             except HedFileError as e:
                 self.assertEqual(e.error_type, error)
+                if filename in self.expected_count:
+                    self.assertEqual(len(e.issues), self.expected_count[filename])
                 pass

--- a/hedtools/tests/validator/test_hed_validator.py
+++ b/hedtools/tests/validator/test_hed_validator.py
@@ -167,9 +167,9 @@ class Test(unittest.TestCase):
 
         validator = HedValidator(hed_schema=hed_schema)
         validation_issues = loaded_file.validate_file(validator)
-        self.assertEqual(len(validation_issues), 3)
+        self.assertEqual(len(validation_issues), 6)
 
-    def test_error_spans_from_file(self):
+    def test_error_spans_from_file_and_missing_required_column(self):
         schema_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                    '../data/hed_pairs/HED8.0.0.mediawiki')
         events_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -195,7 +195,6 @@ class Test(unittest.TestCase):
         test_string = HedString(string_with_def)
         issues = test_string.validate([validator, def_mapper], check_for_definitions=True)
         self.assertEqual(len(issues), 0)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
… of warnings on a HedInput that isn't retrieving every column.

Add HED_SCHEMA_WIKI_WARNINGS, a HedFileError that will contain a list of issues with a wiki file, rather than a single issue.
Slightly tweak how the iterators work on the BaseInput.  They now run the validators directly as they go and return issues in the row dict.  The BaseInput.validate function should work virtually identically.