### PR TITLE
Made check_for_warnings a translate_ops param

### DIFF
--- a/hedtools/hed/errors/exceptions.py
+++ b/hedtools/hed/errors/exceptions.py
@@ -74,6 +74,7 @@ class HedFileError(Exception):
             HedExceptions.HED_END_INVALID: f"{error_prefix}{self.message}.  '{filename}'",
             HedExceptions.INVALID_SECTION_SEPARATOR: f"{error_prefix}{self.message}.  '{filename}'",
             HedExceptions.HED_SCHEMA_NODE_NAME_INVALID: f"{error_prefix}{self.message}.  '{filename}'",
+            HedExceptions.HED_SCHEMA_WIKI_WARNINGS: f"{error_prefix}{self.message}.  '{filename}'",
         }
         default_error_message = f'{error_prefix}Internal Error'
         error_message = error_types.get(error_type, default_error_message)

--- a/hedtools/hed/models/column_mapper.py
+++ b/hedtools/hed/models/column_mapper.py
@@ -52,6 +52,7 @@ class ColumnMapper:
 
         self._na_patterns = ["n/a", "nan"]
         self._finalize_mapping_issues = []
+        self._has_sidecars = False
         if sidecars:
             self.add_sidecars(sidecars)
         self.add_columns(attribute_columns)
@@ -71,6 +72,7 @@ class ColumnMapper:
         sidecars : [str or Sidecar]
             A list of filenames or loaded files in any mix
         """
+        self._has_sidecars = True
         sidecars = Sidecar.load_multiple_sidecars(sidecars)
         for sidecar in sidecars:
             for column_data in sidecar:
@@ -311,7 +313,7 @@ class ColumnMapper:
                     found_named_tag_columns[column_name] = column_number
                 elif column_name.startswith(PANDAS_COLUMN_PREFIX_TO_IGNORE):
                     continue
-                else:
+                elif self._has_sidecars:
                     if column_number not in all_tag_columns:
                         self._finalize_mapping_issues += ErrorHandler.format_error(ValidationErrors.HED_UNKNOWN_COLUMN,
                                                                                    extra_column_name=column_name)

--- a/hedtools/hed/models/util.py
+++ b/hedtools/hed/models/util.py
@@ -18,6 +18,7 @@ def translate_ops(validators, split_tag_and_string_ops=False, **kwargs):
                                    check_for_definitions
                                    expand_defs
                                    error_handler
+                                   check_for_warnings
     Returns
     -------
     tag_ops, string_ops: ([func], [func]) or [func]

--- a/hedtools/hed/schema/hed_schema_section.py
+++ b/hedtools/hed/schema/hed_schema_section.py
@@ -109,8 +109,10 @@ class HedSchemaSection:
         if not self.case_sensitive:
             name_key = name.lower()
 
-        if name_key in self.all_names:
-            print(f"NotImplemented: {name_key} found twice in schema.")
+        # todo: could add this check back and improve.
+        #  This detects two FULLY identical tags, including all terms and parents.
+        # if name_key in self.all_names:
+        #     print(f"NotImplemented: {name_key} found twice in schema.")
         new_entry = HedSchemaEntry(name, self)
         self.all_names[name_key] = new_entry
 

--- a/hedtools/tests/models/test_events_file_input.py
+++ b/hedtools/tests/models/test_events_file_input.py
@@ -33,7 +33,7 @@ class Test(unittest.TestCase):
 
         validation_issues = input_file.validate_file_sidecars(validator)
         self.assertEqual(len(validation_issues), 0)
-        validation_issues = input_file.validate_file(validator)
+        validation_issues = input_file.validate_file(validator, check_for_warnings=True)
         self.assertEqual(len(validation_issues), 1)
 
     def test_expand_column_issues(self):
@@ -52,7 +52,7 @@ class Test(unittest.TestCase):
 
         validation_issues = input_file.validate_file_sidecars(validator)
         self.assertEqual(len(validation_issues), 0)
-        validation_issues = input_file.validate_file(validator)
+        validation_issues = input_file.validate_file(validator, check_for_warnings=True)
         self.assertEqual(len(validation_issues), 1)
 
 

--- a/hedtools/tests/models/test_onset_mapper.py
+++ b/hedtools/tests/models/test_onset_mapper.py
@@ -270,7 +270,7 @@ class Test(TestHedBase):
         def_string.validate(def_dict)
         def_mapper = DefinitionMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
-        hed_validator = HedValidator(hed_schema=self.hed_schema, check_for_warnings=False)
+        hed_validator = HedValidator(hed_schema=self.hed_schema)
         validators = [hed_validator, def_mapper, onset_mapper]
 
         test_strings = [

--- a/hedtools/tests/models/test_sidecar.py
+++ b/hedtools/tests/models/test_sidecar.py
@@ -84,14 +84,14 @@ class Test(unittest.TestCase):
     #
 
     def test_validate_column_group(self):
-        validator = HedValidator(hed_schema=None, check_for_warnings=True)
-        validation_issues = self.json_def_sidecar.validate_entries(validator)
+        validator = HedValidator(hed_schema=None)
+        validation_issues = self.json_def_sidecar.validate_entries(validator, check_for_warnings=True)
         self.assertEqual(len(validation_issues), 0)
 
-        validation_issues = self.default_sidecar.validate_entries(validator)
+        validation_issues = self.default_sidecar.validate_entries(validator, check_for_warnings=True)
         self.assertEqual(len(validation_issues), 0)
 
-        validation_issues = self.errors_sidecar.validate_entries(validator)
+        validation_issues = self.errors_sidecar.validate_entries(validator, check_for_warnings=True)
         self.assertEqual(len(validation_issues), 15)
 
 

--- a/hedtools/tests/validator/test_hed_validator.py
+++ b/hedtools/tests/validator/test_hed_validator.py
@@ -69,7 +69,7 @@ class Test(unittest.TestCase):
 
     def test__validate_input_major_errors_columns(self):
         name = "DummyDisplayFilename.txt"
-        validation_issues = self.hed_file_with_major_errors.validate_file(self.generic_hed_input_reader, name=name)
+        validation_issues = self.hed_file_with_major_errors.validate_file(self.generic_hed_input_reader, check_for_warnings=True, name=name)
         self.assertIsInstance(validation_issues, list)
         self.assertTrue(name in validation_issues[0][ErrorContext.FILE_NAME])
 
@@ -120,16 +120,16 @@ class Test(unittest.TestCase):
         hed_schema = schema.load_schema(schema_path)
         json_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                  "../data/validator_tests/bids_events_bad_defs.json")
-        validator = HedValidator(hed_schema=hed_schema, check_for_warnings=True)
+        validator = HedValidator(hed_schema=hed_schema)
         sidecar = Sidecar(json_path)
-        issues = sidecar.validate_entries(validators=validator)
+        issues = sidecar.validate_entries(validators=validator, check_for_warnings=True)
         self.assertEqual(len(issues), 4)
         input_file = EventsInput(events_path, sidecars=sidecar)
 
-        validation_issues = input_file.validate_file_sidecars(validator)
+        validation_issues = input_file.validate_file_sidecars(validator, check_for_warnings=True)
         self.assertEqual(len(validation_issues), 4)
 
-        validation_issues = input_file.validate_file(validator)
+        validation_issues = input_file.validate_file(validator, check_for_warnings=True)
         self.assertEqual(len(validation_issues), 42)
 
     def test_complex_file_validation_invalid_definitions_removed(self):
@@ -166,8 +166,8 @@ class Test(unittest.TestCase):
                                worksheet_name='LKT Events')
 
         validator = HedValidator(hed_schema=hed_schema)
-        validation_issues = loaded_file.validate_file(validator)
-        self.assertEqual(len(validation_issues), 6)
+        validation_issues = loaded_file.validate_file(validator, check_for_warnings=True)
+        self.assertEqual(len(validation_issues), 3)
 
     def test_error_spans_from_file_and_missing_required_column(self):
         schema_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),

--- a/hedtools/tests/validator/test_tag_validator.py
+++ b/hedtools/tests/validator/test_tag_validator.py
@@ -2,6 +2,7 @@ import unittest
 
 from hed.errors.error_types import ValidationErrors
 from tests.validator.test_tag_validator_base import TestValidatorBase
+from functools import partial
 
 
 class TestHed3(TestValidatorBase):
@@ -10,8 +11,8 @@ class TestHed3(TestValidatorBase):
 
 class IndividualHedTagsShort(TestHed3):
     @staticmethod
-    def string_obj_func(validator):
-        return validator._validate_individual_tags_in_hed_string
+    def string_obj_func(validator, check_for_warnings):
+        return partial(validator._validate_individual_tags_in_hed_string, check_for_warnings=check_for_warnings)
 
     def test_exist_in_schema(self):
         test_strings = {
@@ -295,7 +296,7 @@ class IndividualHedTagsShort(TestHed3):
 
 class TestTagLevels3(TestHed3):
     @staticmethod
-    def string_obj_func(validator):
+    def string_obj_func(validator, check_for_warnings):
         return validator._validate_groups_in_hed_string
 
     def test_no_duplicates(self):
@@ -411,7 +412,7 @@ class FullHedString(TestHed3):
     compute_forms = False
 
     @staticmethod
-    def string_obj_func(validator):
+    def string_obj_func(validator, check_for_warnings):
         return validator._tag_validator.run_hed_string_validators
 
     def test_invalid_placeholders(self):

--- a/hedtools/tests/validator/test_tag_validator_2g.py
+++ b/hedtools/tests/validator/test_tag_validator_2g.py
@@ -3,6 +3,7 @@ import unittest
 from hed.models.hed_string import HedString
 from hed.errors.error_types import ValidationErrors
 from tests.validator.test_tag_validator_base import TestValidatorBase
+from functools import partial
 
 
 class TestHed(TestValidatorBase):
@@ -13,7 +14,7 @@ class FullHedString(TestHed):
     compute_forms = False
 
     @staticmethod
-    def string_obj_func(validator):
+    def string_obj_func(validator, check_for_warnings):
         return validator._tag_validator.run_hed_string_validators
 
     def test_mismatched_parentheses(self):
@@ -330,8 +331,8 @@ class FullHedString(TestHed):
 
 class IndividualHedTags(TestHed):
     @staticmethod
-    def string_obj_func(validator):
-        return validator._validate_individual_tags_in_hed_string
+    def string_obj_func(validator, check_for_warnings):
+        return partial(validator._validate_individual_tags_in_hed_string, check_for_warnings=check_for_warnings)
 
     def test_exist_in_schema(self):
         test_strings = {
@@ -552,7 +553,7 @@ class IndividualHedTags(TestHed):
 
 class HedTagLevels(TestHed):
     @staticmethod
-    def string_obj_func(validator):
+    def string_obj_func(validator, check_for_warnings):
         return validator._validate_groups_in_hed_string
 
     def test_no_duplicates(self):
@@ -596,8 +597,8 @@ class HedTagLevels(TestHed):
 
 class RequiredTags(TestHed):
     @staticmethod
-    def string_obj_func(validator):
-        return validator._validate_tags_in_hed_string
+    def string_obj_func(validator, check_for_warnings):
+        return partial(validator._validate_tags_in_hed_string, check_for_warnings=check_for_warnings)
 
     def test_includes_all_required_tags(self):
         test_strings = {
@@ -665,7 +666,7 @@ class TestHedInvalidChars(TestHed):
     compute_forms = False
 
     @staticmethod
-    def string_obj_func(validator):
+    def string_obj_func(validator, check_for_warnings):
         return validator._tag_validator.run_hed_string_validators
 
     def test_no_more_than_two_tildes(self):
@@ -723,8 +724,8 @@ class TestOldHed(TestHed):
 
 class OldIndividualHedTags(TestOldHed):
     @staticmethod
-    def string_obj_func(validator):
-        return validator._validate_individual_tags_in_hed_string
+    def string_obj_func(validator, check_for_warnings):
+        return partial(validator._validate_individual_tags_in_hed_string, check_for_warnings=check_for_warnings)
 
     def test_required_units(self):
         test_strings = {

--- a/hedtools/tests/validator/test_tag_validator_3g_old_style.py
+++ b/hedtools/tests/validator/test_tag_validator_3g_old_style.py
@@ -2,6 +2,7 @@ import unittest
 
 from hed.errors.error_types import ValidationErrors
 from tests.validator.test_tag_validator_base import TestValidatorBase
+from functools import partial
 
 
 class TestHed3(TestValidatorBase):
@@ -10,8 +11,8 @@ class TestHed3(TestValidatorBase):
 
 class IndividualHedTagsShort(TestHed3):
     @staticmethod
-    def string_obj_func(validator):
-        return validator._validate_individual_tags_in_hed_string
+    def string_obj_func(validator, check_for_warnings):
+        return partial(validator._validate_individual_tags_in_hed_string, check_for_warnings=check_for_warnings)
 
     def test_exist_in_schema(self):
         test_strings = {
@@ -255,7 +256,7 @@ class IndividualHedTagsShort(TestHed3):
 
 class TestTagLevels3(TestHed3):
     @staticmethod
-    def string_obj_func(validator):
+    def string_obj_func(validator, check_for_warnings):
         return validator._validate_groups_in_hed_string
 
     def test_no_duplicates(self):

--- a/hedtools/tests/validator/test_tag_validator_base.py
+++ b/hedtools/tests/validator/test_tag_validator_base.py
@@ -72,17 +72,11 @@ class TestValidatorBase(TestHedBase):
         super().setUpClass()
         cls.error_handler = error_reporter.ErrorHandler()
         cls.syntactic_hed_input_reader = HedValidator(hed_schema=None,
-                                                      run_semantic_validation=False, check_for_warnings=False)
+                                                      run_semantic_validation=False)
         cls.syntactic_tag_validator = cls.syntactic_hed_input_reader._tag_validator
-        cls.syntactic_warning_hed_input_reader = HedValidator(hed_schema=None,
-                                                              run_semantic_validation=False, check_for_warnings=True)
-        cls.syntactic_warning_tag_validator = cls.syntactic_warning_hed_input_reader._tag_validator
         cls.semantic_hed_input_reader = HedValidator(hed_schema=cls.hed_schema,
-                                                     run_semantic_validation=True, check_for_warnings=False)
+                                                     run_semantic_validation=True)
         cls.semantic_tag_validator = cls.semantic_hed_input_reader._tag_validator
-        cls.semantic_warning_hed_input_reader = HedValidator(hed_schema=cls.hed_schema,
-                                                             run_semantic_validation=True, check_for_warnings=True)
-        cls.semantic_warning_tag_validator = cls.semantic_warning_hed_input_reader._tag_validator
 
     def validator_base(self, test_strings, expected_results, expected_issues, test_function,
                        hed_schema=None):
@@ -111,15 +105,11 @@ class TestValidatorBase(TestHedBase):
 
     def validator_syntactic(self, test_strings, expected_results, expected_issues, check_for_warnings):
         validator = self.syntactic_hed_input_reader
-        if check_for_warnings is True:
-            validator = self.syntactic_warning_hed_input_reader
         self.validator_base(test_strings, expected_results, expected_issues,
-                            self.string_obj_func(validator))
+                            self.string_obj_func(validator, check_for_warnings=check_for_warnings))
 
     def validator_semantic(self, test_strings, expected_results, expected_issues, check_for_warnings):
         validator = self.semantic_hed_input_reader
-        if check_for_warnings is True:
-            validator = self.semantic_warning_hed_input_reader
         self.validator_base(test_strings, expected_results, expected_issues,
-                            self.string_obj_func(validator),
+                            self.string_obj_func(validator, check_for_warnings=check_for_warnings),
                             hed_schema=validator._hed_schema)

--- a/hedtools/tests/validator/test_tag_validator_library.py
+++ b/hedtools/tests/validator/test_tag_validator_library.py
@@ -7,6 +7,7 @@ from hed.errors.error_types import ValidationErrors
 from hed.schema.hed_schema_group import HedSchemaGroup
 from hed.errors.exceptions import HedFileError
 from tests.validator.test_tag_validator_base import TestValidatorBase
+from functools import partial
 
 
 class TestHed3(TestValidatorBase):
@@ -42,8 +43,8 @@ class TestHed3(TestValidatorBase):
 
 class IndividualHedTagsShort(TestHed3):
     @staticmethod
-    def string_obj_func(validator):
-        return validator._validate_individual_tags_in_hed_string
+    def string_obj_func(validator, check_for_warnings):
+        return partial(validator._validate_individual_tags_in_hed_string, check_for_warnings=check_for_warnings)
 
     def test_exist_in_schema(self):
         test_strings = {
@@ -305,7 +306,7 @@ class IndividualHedTagsShort(TestHed3):
 
 class TestTagLevels3(TestHed3):
     @staticmethod
-    def string_obj_func(validator):
+    def string_obj_func(validator, check_for_warnings):
         return validator._validate_groups_in_hed_string
 
     def test_no_duplicates(self):


### PR DESCRIPTION
Add ability to filter out mapper warnings with that param
Remove HedValidator._check_for_warnings(now passed as noted above)
Remove a few print statements
Update cache to return 'time since last update' rather than print an error message on failure.