### PR TITLE
Corrections to generate_sidecar_entry and some renaming

### DIFF
--- a/docs/source/generated/hed.models.HedGroup.rst
+++ b/docs/source/generated/hed.models.HedGroup.rst
@@ -31,8 +31,8 @@
       ~HedGroup.groups
       ~HedGroup.lower
       ~HedGroup.make_tag_mutable
-      ~HedGroup.remove_groups
-      ~HedGroup.replace_tag
+      ~HedGroup.remove
+      ~HedGroup.replace
       ~HedGroup.tags
    
    

--- a/docs/source/generated/hed.models.HedString.rst
+++ b/docs/source/generated/hed.models.HedString.rst
@@ -38,8 +38,8 @@
       ~HedString.lower
       ~HedString.make_tag_mutable
       ~HedString.remove_definitions
-      ~HedString.remove_groups
-      ~HedString.replace_tag
+      ~HedString.remove
+      ~HedString.replace
       ~HedString.split_hed_string
       ~HedString.split_into_groups
       ~HedString.tags

--- a/hed/models/__init__.py
+++ b/hed/models/__init__.py
@@ -3,8 +3,8 @@
 from .base_input import BaseInput
 from .column_mapper import ColumnMapper
 from .column_metadata import ColumnMetadata, ColumnType
-from .def_dict import DefDict, DefEntry
-from .def_mapper import DefinitionMapper
+from .definition_dict import DefinitionDict, DefinitionEntry
+from .def_mapper import DefMapper
 from .events_input import EventsInput
 from .hed_group import HedGroup, HedGroupFrozen
 from .hed_group_base import HedGroupBase

--- a/hed/models/base_input.py
+++ b/hed/models/base_input.py
@@ -3,7 +3,7 @@ import openpyxl
 import pandas
 import copy
 
-from hed.models.def_dict import DefDict
+from hed.models.definition_dict import DefinitionDict
 from hed.models.column_mapper import ColumnMapper
 from hed.errors.exceptions import HedFileError, HedExceptions
 from hed.errors.error_types import ErrorContext, ErrorSeverity
@@ -12,7 +12,7 @@ from hed.models import model_constants
 from hed.models.hed_ops import translate_ops
 from hed.models.onset_mapper import OnsetMapper
 from hed.models.hed_string_comb import HedStringComb
-from hed.models.def_mapper import DefinitionMapper
+from hed.models.def_mapper import DefMapper
 
 
 class BaseInput:
@@ -520,7 +520,7 @@ class BaseInput:
             error_handler = ErrorHandler()
 
         error_handler.push_error_context(ErrorContext.FILE_NAME, name)
-        validation_issues = self.get_def_and_mapper_issues(error_handler, check_for_warnings)
+        validation_issues = self.get_def_and_mapper_issues(error_handler, check_for_warnings=check_for_warnings)
         validation_issues += self._run_validators(hed_ops, error_handler=error_handler,
                                                   check_for_warnings=check_for_warnings, **kwargs)
         error_handler.pop_error_context()
@@ -534,12 +534,12 @@ class BaseInput:
             error_handler (ErrorHandler): The error handler to use for context or a default if None.
 
         Returns:
-            DefDict: Contains all the definitions located in the file.
+            DefinitionDict: Contains all the definitions located in the file.
 
         """
         if error_handler is None:
             error_handler = ErrorHandler()
-        new_def_dict = DefDict()
+        new_def_dict = DefinitionDict()
         hed_ops = [new_def_dict]
         _ = self._run_validators(hed_ops, run_on_raw=True, error_handler=error_handler)
         return new_def_dict
@@ -548,7 +548,7 @@ class BaseInput:
         """ Add label definitions gathered from the given input if this has a definition mapper.
 
         Args:
-            def_dict (list or DefDict): Add the DefDict or list of DefDict to the internal definition mapper.
+            def_dict (list or DefinitionDict): Add the DefDict or list of DefDict to the internal definition mapper.
 
         """
         if self._def_mapper is not None:
@@ -573,7 +573,7 @@ class BaseInput:
         return tag_funcs, string_funcs
 
     def _add_def_onset_mapper(self, hed_ops):
-        if not any(isinstance(hed_op, DefinitionMapper) for hed_op in hed_ops):
+        if not any(isinstance(hed_op, DefMapper) for hed_op in hed_ops):
             if self._def_mapper:
                 hed_ops.append(self._def_mapper)
                 hed_ops.append(OnsetMapper(self._def_mapper))

--- a/hed/models/column_mapper.py
+++ b/hed/models/column_mapper.py
@@ -350,7 +350,7 @@ class ColumnMapper:
         """ Return a list of all def dicts from every column description.
 
         Returns:
-           list:   A list of DefDict objects corresponding to each column entry.
+           list:   A list of DefinitionDict objects corresponding to each column entry.
 
         """
         def_dicts = [entry.def_dict for entry in self.column_data.values()]

--- a/hed/models/column_metadata.py
+++ b/hed/models/column_metadata.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from hed.models.hed_string import HedString
-from hed.models.def_dict import DefDict
+from hed.models.definition_dict import DefinitionDict
 from hed.errors.error_types import SidecarErrors, ErrorContext, ValidationErrors
 from hed.errors import error_reporter
 from hed.errors.error_reporter import ErrorHandler
@@ -63,7 +63,7 @@ class ColumnMetadata:
         """ Return the definition dictionary for this column.
 
         Returns:
-            DefDict: Contains all the definitions located in the column.
+            DefinitionDict: Contains all the definitions located in the column.
 
         """
         return self._def_dict
@@ -428,12 +428,12 @@ class ColumnMetadata:
             error_handler (ErrorHandler): The error handler to use for context, uses a default one if None.
 
         Returns:
-            DefDict: Contains all the definitions located in the column.
+            DefinitionDict: Contains all the definitions located in the column.
 
         """
         if error_handler is None:
             error_handler = ErrorHandler()
-        new_def_dict = DefDict()
+        new_def_dict = DefinitionDict()
         hed_ops = []
         hed_ops.append(new_def_dict)
         hed_ops.append(HedString.remove_definitions)

--- a/hed/models/definition_dict.py
+++ b/hed/models/definition_dict.py
@@ -9,7 +9,7 @@ from hed.models.model_constants import DefTagNames
 from hed.models.hed_ops import HedOps
 
 
-class DefEntry:
+class DefinitionEntry:
     """ Represents a single definition."""
 
     def __init__(self, name, contents, takes_value, source_context):
@@ -72,7 +72,7 @@ class DefEntry:
         return f"{DefTagNames.DEF_EXPAND_ORG_KEY}/{name}", output_contents
 
 
-class DefDict(HedOps):
+class DefinitionDict(HedOps):
     """Class responsible for gathering and storing a group of definitions to be considered a single source.
 
         A bids_old style file might have many of these(one for each json dict, and another for the actual file).
@@ -103,7 +103,7 @@ class DefDict(HedOps):
             Provides direct access to internal dictionary.  Alter at your own risk.
         Returns
         -------
-        def_dict: {str: DefEntry}
+        def_dict: {str: DefinitionEntry}
         """
         return self._defs
 
@@ -195,9 +195,9 @@ class DefDict(HedOps):
                                                                          DefinitionErrors.DUPLICATE_DEFINITION,
                                                                          def_name=def_tag_name)
                 continue
-            self._defs[def_tag_lower] = DefEntry(name=def_tag_name, contents=group_tag,
-                                                 takes_value=def_takes_value,
-                                                 source_context=context)
+            self._defs[def_tag_lower] = DefinitionEntry(name=def_tag_name, contents=group_tag,
+                                                        takes_value=def_takes_value,
+                                                        source_context=context)
 
         self._extract_def_issues += new_def_issues
         return new_def_issues

--- a/hed/models/events_input.py
+++ b/hed/models/events_input.py
@@ -1,7 +1,7 @@
 from hed.models.column_mapper import ColumnMapper
 from hed.models.base_input import BaseInput
 from hed.models.sidecar import Sidecar
-from hed.models.def_mapper import DefinitionMapper
+from hed.models.def_mapper import DefMapper
 
 
 class EventsInput(BaseInput):
@@ -22,8 +22,8 @@ class EventsInput(BaseInput):
         attribute_columns: str or int or [str] or [int]
             A list of column names or numbers to treat as attributes.
             Default: ["duration", "onset"]
-        extra_def_dicts: [DefDict] or DefDict or None
-            DefDict objects containing all the definitions this file should use other than the ones coming from the file
+        extra_def_dicts: [DefinitionDict] or DefinitionDict or None
+            DefinitionDict objects containing all the definitions this file should use other than the ones coming from the file
             itself and from the column def groups.  These are added as the last entries, so names will override
             earlier ones.
         also_gather_defs: bool
@@ -59,11 +59,11 @@ class EventsInput(BaseInput):
         ----------
         column_mapper : ColumnMapper
             The column mapper to gather definitions from
-        extra_def_dicts : DefDict or [DefDict]
+        extra_def_dicts : DefinitionDict or [DefinitionDict]
             Optional. Adds any definitions in these to the def mapper as well, in addition to any found in the columns.
         Returns
         -------
-        def mapper: DefinitionMapper
+        def mapper: DefMapper
             A class to validate or expand definitions with the given def dicts.
         """
         def_dicts = []
@@ -74,7 +74,7 @@ class EventsInput(BaseInput):
             extra_def_dicts = [extra_def_dicts]
         if extra_def_dicts:
             def_dicts += extra_def_dicts
-        def_mapper = DefinitionMapper(def_dicts)
+        def_mapper = DefMapper(def_dicts)
 
         return def_mapper
 

--- a/hed/models/expression_parser.py
+++ b/hed/models/expression_parser.py
@@ -150,7 +150,7 @@ class TagExpressionParser:
     def __init__(self, expression_string):
         self.tokens = []
         self.at_token = -1
-        self.tree = self._parse(expression_string)
+        self.tree = self._parse(expression_string.lower())
         self._org_string = expression_string
 
     def _get_next_token(self):
@@ -246,6 +246,8 @@ class TagExpressionParser:
 
 if __name__ == '__main__':
     from hed.models.hed_string import HedStringFrozen
+    from hed.schema.hed_schema_io import load_schema_version
+    hed_schema = load_schema_version(xml_version='8.0.0')
     my_string = "Sensory-event,(Intended-effect,Cue),((Def-expand/Circle-only," + \
                 "(Visual-presentation,(Foreground-view,((White,Circle)," + \
                 "(Center-of,Computer-screen))),(Background-view,Black))),Onset)," + \
@@ -255,97 +257,98 @@ if __name__ == '__main__':
                 "(Task,Experiment-participant,Inhibit-blinks)),Offset)," + \
                 "((Def-expand/Fixation-task,(Task,Experiment-participant,(Fixate,Cross)" + \
                 ")),Offset),Experimental-trial/1,(Image,Pathname/circle.bmp)"
-    hed_string = HedStringFrozen(my_string)
-    my_string1 = "Sensory-event,(Intended-effect,Cue)"
-    hed_string1 = HedStringFrozen(my_string1)
-    expression1 = TagExpressionParser("Sensory-event")
-    result1 = expression1.search_hed_string(hed_string1)
-    expression2 = TagExpressionParser("[Sensory-event, Cue]")
-    result2 = expression2.search_hed_string(hed_string1)
-    print("to here")
-    # expression = TagExpressionParser("[[a,b]]")
-    # hed_string = HedStringFrozen("A, C, D, B")
-    # x = expression.search_hed_string(hed_string)
-    # print(expression.search_hed_string(hed_string), False)  # False
-    # hed_string = HedStringFrozen("(A, B, C, D)")
-    # y = expression.search_hed_string(hed_string)
-    # print(expression.search_hed_string(hed_string), True)  # True
-    # hed_string = HedStringFrozen("(A, C, D, B)")
-    # print(expression.search_hed_string(hed_string), True)  # True
+    hed_string = HedStringFrozen(my_string, hed_schema=hed_schema)
+    my_string1 = "sensory-event,(intended-effect,cue)"
+    hed_string1 = HedStringFrozen(my_string1, hed_schema=hed_schema)
+    expression1 = TagExpressionParser("sensory-event")
+    print(expression1.search_hed_string(hed_string1), True)
+    expression2 = TagExpressionParser("sensory-event, cue")
+    print(expression2.search_hed_string(hed_string1), True)
+    expression3 = TagExpressionParser("onset")
+    print(expression3.search_hed_string(hed_string), True)
+    expression = TagExpressionParser("[[a,b]]")
+    hed_string = HedStringFrozen("A, C, D, B")
+    x = expression.search_hed_string(hed_string)
+    print(expression.search_hed_string(hed_string), False)  # False
+    hed_string = HedStringFrozen("(A, B, C, D)")
+    y = expression.search_hed_string(hed_string)
+    print(expression.search_hed_string(hed_string), True)  # True
+    hed_string = HedStringFrozen("(A, C, D, B)")
+    print(expression.search_hed_string(hed_string), True)  # True
 
     # Doesn't handle and/or precedence well(right to left and equal precedent currently)
-    # expression = TagExpressionParser("a and b or c")
-    # hed_string = HedStringFrozen("B")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    # hed_string = HedStringFrozen("A, B")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    # hed_string = HedStringFrozen("A, C")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    # hed_string = HedStringFrozen("C")
-    # print(expression.search_hed_string(hed_string), True)  # TRue
-    #
-    # expression = TagExpressionParser("a or b and c")
-    # hed_string = HedStringFrozen("B")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    # hed_string = HedStringFrozen("A, B")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    # hed_string = HedStringFrozen("A, C")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    # hed_string = HedStringFrozen("C")
-    # print(expression.search_hed_string(hed_string), False)  # false
-    # hed_string = HedStringFrozen("A")
-    # print(expression.search_hed_string(hed_string), False)  # false
-    #
-    # expression = TagExpressionParser("a and (b or c)")
-    # hed_string = HedStringFrozen("A, C")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    #
-    # expression = TagExpressionParser("[[a,b]] or [[c, d]]")
-    # hed_string = HedStringFrozen("(c, d)")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    # hed_string = HedStringFrozen("(b, d)")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    # hed_string = HedStringFrozen("(b, a)")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    #
-    # expression = TagExpressionParser("[[a,b]] and [[c, d]]")
-    # hed_string = HedStringFrozen("(c, d, a, b)")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    # hed_string = HedStringFrozen("(c, d, a)")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    # hed_string = HedStringFrozen("(c, d), (a, b)")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    # breakHere = 3
-    #
-    # expression = TagExpressionParser("[[a,b]] and d")
-    # hed_string = HedStringFrozen("(a, b), d")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    #
-    # expression = TagExpressionParser("[[a,b]] and d")
-    # hed_string = HedStringFrozen("(a, b), c")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    #
-    # expression = TagExpressionParser("[[a,b]] or d")
-    # hed_string = HedStringFrozen("d")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    #
-    # hed_string = HedStringFrozen("a, b")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    #
-    # expression = TagExpressionParser("[[a,b,[[c,d]]]]")
-    # # # Should this be valid?  It's iffy.
-    # hed_string = HedStringFrozen("(a, b, c, d)")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    #
-    # hed_string = HedStringFrozen("(a, b, (c, d))")
-    # y = expression.search_hed_string(hed_string)
-    # print(expression.search_hed_string(hed_string), True)  # True
-    #
-    # expression = TagExpressionParser("[[a,b,[[c,d, [[e, f]]]]]]")
-    # hed_string = HedStringFrozen("(a, b, ((e, f), c, d))")
-    # print(expression.search_hed_string(hed_string), True)  # True
-    #
-    # expression = TagExpressionParser("[[a,b,[[c,d, [[e, f]]]]]]")
-    # hed_string = HedStringFrozen("(a, b, (e, f, c, d))")
-    # print(expression.search_hed_string(hed_string), False)  # False
-    #
+    expression = TagExpressionParser("a and b or c")
+    hed_string = HedStringFrozen("B")
+    print(expression.search_hed_string(hed_string), False)  # False
+    hed_string = HedStringFrozen("A, B")
+    print(expression.search_hed_string(hed_string), True)  # True
+    hed_string = HedStringFrozen("A, C")
+    print(expression.search_hed_string(hed_string), True)  # True
+    hed_string = HedStringFrozen("C")
+    print(expression.search_hed_string(hed_string), True)  # TRue
+
+    expression = TagExpressionParser("a or b and c")
+    hed_string = HedStringFrozen("B")
+    print(expression.search_hed_string(hed_string), False)  # False
+    hed_string = HedStringFrozen("A, B")
+    print(expression.search_hed_string(hed_string), False)  # False
+    hed_string = HedStringFrozen("A, C")
+    print(expression.search_hed_string(hed_string), True)  # True
+    hed_string = HedStringFrozen("C")
+    print(expression.search_hed_string(hed_string), False)  # false
+    hed_string = HedStringFrozen("A")
+    print(expression.search_hed_string(hed_string), False)  # false
+
+    expression = TagExpressionParser("a and (b or c)")
+    hed_string = HedStringFrozen("A, C")
+    print(expression.search_hed_string(hed_string), True)  # True
+
+    expression = TagExpressionParser("[[a,b]] or [[c, d]]")
+    hed_string = HedStringFrozen("(c, d)")
+    print(expression.search_hed_string(hed_string), True)  # True
+    hed_string = HedStringFrozen("(b, d)")
+    print(expression.search_hed_string(hed_string), False)  # False
+    hed_string = HedStringFrozen("(b, a)")
+    print(expression.search_hed_string(hed_string), True)  # True
+
+    expression = TagExpressionParser("[[a,b]] and [[c, d]]")
+    hed_string = HedStringFrozen("(c, d, a, b)")
+    print(expression.search_hed_string(hed_string), True)  # True
+    hed_string = HedStringFrozen("(c, d, a)")
+    print(expression.search_hed_string(hed_string), False)  # False
+    hed_string = HedStringFrozen("(c, d), (a, b)")
+    print(expression.search_hed_string(hed_string), True)  # True
+    breakHere = 3
+
+    expression = TagExpressionParser("[[a,b]] and d")
+    hed_string = HedStringFrozen("(a, b), d")
+    print(expression.search_hed_string(hed_string), True)  # True
+
+    expression = TagExpressionParser("[[a,b]] and d")
+    hed_string = HedStringFrozen("(a, b), c")
+    print(expression.search_hed_string(hed_string), False)  # False
+
+    expression = TagExpressionParser("[[a,b]] or d")
+    hed_string = HedStringFrozen("d")
+    print(expression.search_hed_string(hed_string), True)  # True
+
+    hed_string = HedStringFrozen("a, b")
+    print(expression.search_hed_string(hed_string), False)  # False
+
+    expression = TagExpressionParser("[[a,b,[[c,d]]]]")
+    # # Should this be valid?  It's iffy.
+    hed_string = HedStringFrozen("(a, b, c, d)")
+    print(expression.search_hed_string(hed_string), False)  # False
+
+    hed_string = HedStringFrozen("(a, b, (c, d))")
+    y = expression.search_hed_string(hed_string)
+    print(expression.search_hed_string(hed_string), True)  # True
+
+    expression = TagExpressionParser("[[a,b,[[c,d, [[e, f]]]]]]")
+    hed_string = HedStringFrozen("(a, b, ((e, f), c, d))")
+    print(expression.search_hed_string(hed_string), True)  # True
+
+    expression = TagExpressionParser("[[a,b,[[c,d, [[e, f]]]]]]")
+    hed_string = HedStringFrozen("(a, b, (e, f, c, d))")
+    print(expression.search_hed_string(hed_string), False)  # False
+

--- a/hed/models/hed_group.py
+++ b/hed/models/hed_group.py
@@ -92,11 +92,11 @@ class HedGroup(HedGroupBase):
 
         return self._check_in_group(tag_or_group, final_list)
 
-    def replace_tag(self, tag_or_group, new_contents):
+    def replace(self, item_to_replace, new_contents):
         """ Replace an existing tag or group in the group with a new tag, list, or group.
 
         Args:
-            tag_or_group (HedTag or HedGroup): The item to  replace.  It must exist or this will raise an error.
+            item_to_replace (HedTag or HedGroup): The item to  replace must exist or this will raise an error.
             new_contents (HedTag, HedGroup or list of HedTag and/or HedGroup): Replacement contents.
 
         Raises:
@@ -111,7 +111,7 @@ class HedGroup(HedGroupBase):
 
         replace_index = -1
         for i, child in enumerate(self._children):
-            if tag_or_group is child:
+            if item_to_replace is child:
                 replace_index = i
                 break
         self._children[replace_index] = new_contents
@@ -150,11 +150,11 @@ class HedGroup(HedGroupBase):
             else:
                 child.mutable = value
 
-    def remove_groups(self, remove_groups):
-        """Remove any tags/groups in remove_groups found in this HedGroup.
+    def remove(self, items_to_remove):
+        """Remove any tags/groups in items_to_remoe found in this HedGroup.
 
         Args:
-            remove_groups (list):  List of HedGroups and/or HedTags to remove.
+            items_to_remove (list):  List of HedGroups and/or HedTags to remove.
 
         Notes:
             Any groups that become empty will also be pruned.
@@ -162,13 +162,13 @@ class HedGroup(HedGroupBase):
 
         """
         all_groups = self.get_all_groups()
-        self._remove_groups(remove_groups, all_groups)
+        self._remove(items_to_remove, all_groups)
 
-    def _remove_groups(self, remove_groups, all_groups):
+    def _remove(self, items_to_remove, all_groups):
         """ Needs to be documented.
 
         Args:
-            remove_groups ( ):
+            items_to_remove ( ):
             all_groups ( ):
 
         Returns:
@@ -178,7 +178,7 @@ class HedGroup(HedGroupBase):
 
         """
         empty_groups = []
-        for remove_child in remove_groups:
+        for remove_child in items_to_remove:
             for group in all_groups:
                 # only proceed if we have an EXACT match for this child
                 if any(remove_child is child for child in group._children):
@@ -194,7 +194,7 @@ class HedGroup(HedGroupBase):
                     break
 
         if empty_groups:
-            return self.remove_groups(empty_groups)
+            return self.remove(empty_groups)
 
     def make_tag_mutable(self, tag):
         """ Replace the given tag in this group with a tag that can be altered and return new version.
@@ -218,7 +218,7 @@ class HedGroup(HedGroupBase):
         if not tag.mutable:
             tag_copy = copy.copy(tag)
             tag_copy.mutable = True
-            self.replace_tag(tag, tag_copy)
+            self.replace(tag, tag_copy)
             return tag_copy
         return tag
 

--- a/hed/models/hed_group_base.py
+++ b/hed/models/hed_group_base.py
@@ -303,7 +303,7 @@ class HedGroupBase:
             If 3 or any other value: Return all 3 as a tuple.
 
         """
-        from hed.models.def_dict import DefTagNames
+        from hed.models.definition_dict import DefTagNames
         if recursive:
             groups = self.get_all_groups()
         else:

--- a/hed/models/hed_input.py
+++ b/hed/models/hed_input.py
@@ -1,6 +1,6 @@
 from hed.models.column_mapper import ColumnMapper
 from hed.models.base_input import BaseInput
-from hed.models.def_mapper import DefinitionMapper
+from hed.models.def_mapper import DefMapper
 
 
 class HedInput(BaseInput):
@@ -21,7 +21,7 @@ class HedInput(BaseInput):
             has_column_names (bool): True if file has column names. Validation will skip over the
                 first line of the file if the spreadsheet as column names.
             column_prefix_dictionary (dict): A dictionary with column number keys and prefix values.
-            def_dicts (DefDict or list):  A DefDict or list of DefDicts containing definitions for this
+            def_dicts (DefinitionDict or list):  A DefinitionDict or list of DefDicts containing definitions for this
                 object other than the ones extracted from the HedInput object itself.
 
         Examples:
@@ -37,7 +37,7 @@ class HedInput(BaseInput):
 
         new_mapper = ColumnMapper(tag_columns=tag_columns, column_prefix_dictionary=column_prefix_dictionary)
 
-        def_mapper = DefinitionMapper(def_dicts)
+        def_mapper = DefMapper(def_dicts)
 
         super().__init__(file, file_type, worksheet_name, has_column_names, new_mapper, def_mapper=def_mapper,
                          name=name)

--- a/hed/models/hed_string.py
+++ b/hed/models/hed_string.py
@@ -68,7 +68,7 @@ class HedString(HedGroup):
         """
         definition_groups = self.find_top_level_tags({DefTagNames.DEFINITION_KEY}, include_groups=1)
         if definition_groups:
-            self.remove_groups(definition_groups)
+            self.remove(definition_groups)
 
         return []
 

--- a/hed/models/hed_string_comb.py
+++ b/hed/models/hed_string_comb.py
@@ -44,9 +44,9 @@ class HedStringComb(HedString):
         """
         return [child for sub_string in self._children for child in sub_string._children]
 
-    def remove_groups(self, remove_groups):
+    def remove(self, items_to_remove):
         """
-            Remove any tags/groups in remove_groups found in this hed string.
+            Remove any tags/groups in remove found in this hed string.
 
             Any groups that become empty will also be pruned.
 
@@ -54,23 +54,23 @@ class HedStringComb(HedString):
 
         Parameters
         ----------
-        remove_groups : [HedGroup or HedTag]
+        items_to_remove : [HedGroup or HedTag]
             A list of groups or tags to remove.
         """
         all_groups = [group for sub_group in self._children for group in sub_group.get_all_groups()]
-        self._remove_groups(remove_groups, all_groups)
+        self._remove(items_to_remove, all_groups)
         # Remove any lingering empty HedStrings
         if any(not hed_string for hed_string in self._children):
             if self._original_children is self._children:
                 self._original_children = self._children.copy()
             self._children = [child for child in self._children if child]
 
-    def replace_tag(self, tag_or_group, new_contents):
+    def replace(self, item_to_replace, new_contents):
         """ Replaces an existing tag in the group with a new tag, list, or group
 
         Parameters
         ----------
-        tag_or_group : HedTag or HedGroup
+        item_to_replace : HedTag or HedGroup
             The tag to replace.  It must exist or this will raise an error.
         new_contents : HedTag or HedGroup or [HedTag or HedGroup]
             What to replace the tag with.
@@ -82,11 +82,11 @@ class HedStringComb(HedString):
         replace_sub_string = None
         for sub_string in self._children:
             for i, child in enumerate(sub_string.children):
-                if tag_or_group is child:
+                if item_to_replace is child:
                     replace_sub_string = sub_string
                     break
 
-        replace_sub_string.replace_tag(tag_or_group, new_contents)
+        replace_sub_string.replace(item_to_replace, new_contents)
 
     def __copy__(self):
         """

--- a/hed/models/sidecar.py
+++ b/hed/models/sidecar.py
@@ -5,7 +5,7 @@ from hed.errors import error_reporter
 from hed.errors import ErrorHandler
 from hed.errors.exceptions import HedFileError, HedExceptions
 from hed.models.hed_string import HedString
-from hed.models.def_mapper import DefinitionMapper
+from hed.models.def_mapper import DefMapper
 
 
 class Sidecar:
@@ -153,7 +153,7 @@ class Sidecar:
             If True, remove all definitions found in the string.
         allow_placeholders: bool
             If False, placeholders will be marked as validation warnings.
-        extra_def_dicts: [DefDict] or DefDict or None
+        extra_def_dicts: [DefinitionDict] or DefinitionDict or None
             Extra dicts to add to the list
         kwargs:
             See models.hed_ops.translate_ops or the specific hed_ops for additional options
@@ -205,9 +205,9 @@ class Sidecar:
         if not isinstance(hed_ops, list):
             hed_ops = [hed_ops]
         hed_ops = hed_ops.copy()
-        if not any(isinstance(hed_op, DefinitionMapper) for hed_op in hed_ops):
+        if not any(isinstance(hed_op, DefMapper) for hed_op in hed_ops):
             def_dicts = self.get_def_dicts(extra_def_dicts)
-            def_mapper = DefinitionMapper(def_dicts)
+            def_mapper = DefMapper(def_dicts)
             hed_ops.append(def_mapper)
         return hed_ops
 
@@ -233,11 +233,11 @@ class Sidecar:
 
         Parameters
         ----------
-        extra_def_dicts: [DefDict] or DefDict or None
+        extra_def_dicts: [DefinitionDict] or DefinitionDict or None
             Extra dicts to add to the list
         Returns
         -------
-        def_dicts: [DefDict]
+        def_dicts: [DefinitionDict]
             A list of def dicts for each column plus any found in extra_def_dicts.
         """
         def_dicts = [column_entry.def_dict for column_entry in self]
@@ -259,7 +259,7 @@ class Sidecar:
         name: str
             If present, will use this as the filename for context, rather than using the actual filename
             Useful for temp filenames.
-        extra_def_dicts: [DefDict] or DefDict or None
+        extra_def_dicts: [DefinitionDict] or DefinitionDict or None
             If present, also use these in addition to the sidecars def dicts.
         error_handler : ErrorHandler or None
             Used to report errors.  Uses a default one if none passed in.

--- a/hed/tools/annotation/annotation_util.py
+++ b/hed/tools/annotation/annotation_util.py
@@ -1,5 +1,6 @@
 """ Utilities to facilitate annotation of events in BIDS. """
 
+import re
 from pandas import DataFrame
 from hed.errors.exceptions import HedFileError
 
@@ -88,19 +89,22 @@ def generate_sidecar_entry(column_name, column_values=None):
 
      Returns:
          dict   A dictionary representing a template for a sidecar entry.
+
     """
 
+    name_label = re.sub(r'[^A-Za-z0-9-]+', '_', column_name)
     sidecar_entry = {"Description": f"Description for {column_name}", "HED": ""}
     if not column_values:
-        sidecar_entry["HED"] = "Label/#"
+        sidecar_entry["HED"] = f"(Label/{name_label}, Label/#)"
     else:
         levels = {}
         hed = {}
         for column_value in column_values:
             if column_value == "n/a":
                 continue
-            levels[column_value] = f"Description for {column_value}"
-            hed[column_value] = f"Label/{column_value}"
+            value_label = re.sub(r'[^A-Za-z0-9-]+', '_', column_value)
+            levels[column_value] = f"Description for {column_value} of {column_name}"
+            hed[column_value] = f"(Label/{name_label}, Label/{value_label})"
         sidecar_entry["Levels"] = levels
         sidecar_entry["HED"] = hed
     return sidecar_entry

--- a/hed/tools/annotation/tag_summary.py
+++ b/hed/tools/annotation/tag_summary.py
@@ -2,8 +2,8 @@ import os
 import json
 from hed.tools.bids.bids_dataset import BidsDataset
 from hed.tools.annotation.summary_util import breakout_tags, extract_dict_values
-from hed.models.def_dict import add_group_to_dict
-from hed.models import DefDict
+from hed.models.definition_dict import add_group_to_dict
+from hed.models import DefinitionDict
 
 DEFAULT_BREAKOUT_LIST = [
     "Sensory-event", "Agent-action", "Event", "Action", "Task-event-role", "Task-action-type",
@@ -42,7 +42,7 @@ class TagSummary:
 
     def _set_all_tags(self):
         schema = self.dataset.schemas
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         self.all_defs_dict = def_dict.defs
         for bids_sidecar in self.dataset.event_files.sidecar_dict.values():
             sidecar = bids_sidecar.contents

--- a/hed/validator/hed_validator.py
+++ b/hed/validator/hed_validator.py
@@ -139,7 +139,7 @@ class HedValidator(HedOps):
              The issues associated with the individual tags in the HED string.
 
          """
-        from hed.models.def_dict import DefTagNames
+        from hed.models.definition_dict import DefTagNames
         validation_issues = []
         def_groups = hed_string_obj.find_top_level_tags(anchor_tags={DefTagNames.DEFINITION_KEY}, include_groups=1)
         all_def_groups = [group for sub_group in def_groups for group in sub_group.get_all_groups()]

--- a/tests/models/test_def_dict.py
+++ b/tests/models/test_def_dict.py
@@ -1,6 +1,6 @@
 import unittest
 
-from hed.models.def_dict import DefDict
+from hed.models.definition_dict import DefinitionDict
 from hed.errors import ErrorHandler, DefinitionErrors
 from hed.models.hed_string import HedString
 from hed import HedTag
@@ -9,7 +9,7 @@ from hed import HedTag
 class TestDefBase(unittest.TestCase):
     def check_def_base(self, test_strings, expected_issues):
         for test_key in test_strings:
-            def_dict = DefDict()
+            def_dict = DefinitionDict()
             hed_string_obj = HedString(test_strings[test_key])
             hed_string_obj.convert_to_canonical_forms(None)
             test_issues = def_dict.check_for_definitions(hed_string_obj)
@@ -32,7 +32,7 @@ class TestDefDict(TestDefBase):
     placeholder_def_string = f"(Definition/TestDefPlaceholder/#,{placeholder_def_contents})"
 
     def test_check_for_definitions(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         original_def_count = len(def_dict._defs)
         hed_string_obj = HedString(self.basic_definition_string)
         hed_string_obj.validate(def_dict)
@@ -40,7 +40,7 @@ class TestDefDict(TestDefBase):
         self.assertGreater(new_def_count, original_def_count)
 
     def test_check_for_definitions_placeholder(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         original_def_count = len(def_dict._defs)
         hed_string_obj = HedString(self.placeholder_def_string)
         hed_string_obj.validate(def_dict)

--- a/tests/models/test_def_mapper.py
+++ b/tests/models/test_def_mapper.py
@@ -2,7 +2,7 @@ import unittest
 import os
 
 from hed import schema
-from hed.models import DefDict, DefinitionMapper, HedString
+from hed.models import DefinitionDict, DefMapper, HedString
 from hed.validator import HedValidator
 
 
@@ -56,12 +56,12 @@ class Test(unittest.TestCase):
                            basic_definition_string=None):
         if not basic_definition_string:
             basic_definition_string = self.basic_definition_string
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(basic_definition_string)
         def_string.convert_to_canonical_forms(None)
         def_dict.check_for_definitions(def_string)
 
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         hed_ops = []
         if extra_ops:
             hed_ops += extra_ops
@@ -118,11 +118,11 @@ class Test(unittest.TestCase):
 
     # special case test
     def test_changing_tag_then_def_mapping(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.basic_definition_string)
         def_string.convert_to_canonical_forms(None)
         def_dict.check_for_definitions(def_string)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         validator = HedValidator(self.hed_schema)
         hed_ops = [validator, def_mapper]
 
@@ -196,11 +196,11 @@ class Test(unittest.TestCase):
                                 extra_ops=extra_ops)
 
     def test_expand_def_tags_placeholder_invalid(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.convert_to_canonical_forms(None)
         def_dict.check_for_definitions(def_string)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
 
         placeholder_label_def_string_no_placeholder = "def/TestDefPlaceholder"
 
@@ -210,11 +210,11 @@ class Test(unittest.TestCase):
         self.assertEqual(str(test_string), placeholder_label_def_string_no_placeholder)
         self.assertTrue(def_issues)
 
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.basic_definition_string)
         def_string.convert_to_canonical_forms(None)
         def_dict.check_for_definitions(def_string)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
 
         label_def_string_has_invalid_placeholder = "def/TestDef/54687"
 
@@ -225,11 +225,11 @@ class Test(unittest.TestCase):
         self.assertTrue(def_issues)
 
     def test_bad_def_expand(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.convert_to_canonical_forms(None)
         def_dict.check_for_definitions(def_string)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
 
         valid_placeholder = HedString(self.placeholder_expanded_def_string)
         def_issues = valid_placeholder.validate(def_mapper)
@@ -240,11 +240,11 @@ class Test(unittest.TestCase):
         self.assertTrue(bool(def_issues))
 
     def test_def_no_content(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString("(Definition/EmptyDef)")
         def_string.convert_to_canonical_forms(None)
         def_dict.check_for_definitions(def_string)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
 
         valid_empty = HedString("Def/EmptyDef")
         def_issues = valid_empty.validate(def_mapper, expand_defs=True)
@@ -257,12 +257,12 @@ class Test(unittest.TestCase):
 
     def test_mutable(self):
         basic_definition_string = "(Definition/TestDef, (Keypad-key/TestDef1,Keyboard-key/TestDef2))"
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(basic_definition_string)
         def_string.convert_to_canonical_forms(self.hed_schema)
         def_dict.check_for_definitions(def_string)
 
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         hed_ops = []
         hed_ops.append(self.hed_schema)
         hed_ops.append(def_mapper)
@@ -278,7 +278,7 @@ class Test(unittest.TestCase):
         tags_to_remove = test_string.find_tags(search_tags=["keypad-key"], recursive=True)
 
         for tag, group in tags_to_remove:
-            test_string.remove_groups([tag])
+            test_string.remove([tag])
 
 
         self.assertEqual(test_string, test_string2)

--- a/tests/models/test_hed_group.py
+++ b/tests/models/test_hed_group.py
@@ -13,13 +13,13 @@ class Test(unittest.TestCase):
         cls.hed_schema = schema.load_schema(hed_xml_file)
 
     def test_remove_groups(self):
-        from hed.models.def_dict import DefTagNames
+        from hed.models.definition_dict import DefTagNames
         basic_definition_string = "(Definition/TestDef, (Keypad-key/TestDef1,Keyboard-key/TestDef2))"
         basic_definition_string_repeated = f"{basic_definition_string},{basic_definition_string}"
         def_string_with_repeat = HedString(basic_definition_string_repeated, self.hed_schema)
         definition_tags = def_string_with_repeat.find_tags({DefTagNames.DEFINITION_KEY}, recursive=True, include_groups=1)
         definition_tag2 = definition_tags[1]
-        def_string_with_repeat.remove_groups([definition_tag2])
+        def_string_with_repeat.remove([definition_tag2])
         remaining_children = def_string_with_repeat.get_all_groups()
         for child in remaining_children:
             if child is definition_tag2:
@@ -29,7 +29,7 @@ class Test(unittest.TestCase):
         def_string_with_repeat = HedString(basic_definition_string_repeated_subgroup, self.hed_schema)
         definition_tags = def_string_with_repeat.find_tags({DefTagNames.DEFINITION_KEY}, recursive=True, include_groups=1)
         definition_tag3 = definition_tags[2]
-        def_string_with_repeat.remove_groups([definition_tag3])
+        def_string_with_repeat.remove([definition_tag3])
         remaining_children = def_string_with_repeat.get_all_groups()
         for child in remaining_children:
             if child is definition_tag3:
@@ -39,7 +39,7 @@ class Test(unittest.TestCase):
         def_string_with_repeat = HedString(basic_definition_string_repeated_subgroup, self.hed_schema)
         definition_tags = def_string_with_repeat.find_tags({DefTagNames.DEFINITION_KEY}, recursive=True, include_groups=1)
         definition_tag2 = definition_tags[1]
-        def_string_with_repeat.remove_groups([definition_tag2])
+        def_string_with_repeat.remove([definition_tag2])
         remaining_children = def_string_with_repeat.get_all_groups()
         for child in remaining_children:
             if child is definition_tag2:

--- a/tests/models/test_hed_string_comb.py
+++ b/tests/models/test_hed_string_comb.py
@@ -23,22 +23,22 @@ class Test(unittest.TestCase):
         self.assertEqual(len(string1.get_all_tags()), 1)
         self.assertEqual(len(string2.get_all_tags()), 3)
         tags = comb_string.find_tags(["Object".lower()], include_groups=0)
-        comb_string.remove_groups(tags)
+        comb_string.remove(tags)
         self.assertEqual(len(string1.get_all_tags()), 0)
         self.assertEqual(len(string2.get_all_tags()), 3)
         self.assertEqual(len(comb_string.get_all_tags()), 3)
 
         tags = comb_string.find_tags(["Event".lower()], recursive=True, include_groups=0)
-        comb_string.remove_groups(tags)
+        comb_string.remove(tags)
         self.assertEqual(len(string2.get_all_tags()), 1)
         self.assertEqual(len(comb_string.get_all_tags()), 1)
 
         tags = comb_string.find_tags(["Square".lower()], recursive=True, include_groups=0)
-        comb_string.remove_groups(tags)
+        comb_string.remove(tags)
         self.assertEqual(len(string2.get_all_tags()), 0)
         self.assertEqual(len(comb_string.get_all_tags()), 0)
 
-    def test_replace_tag(self):
+    def test_replace(self):
         string1 = HedString("Item/Object", self.hed_schema)
         string2 = HedString("Event, (Event, Square)", self.hed_schema)
         new_contents = HedTag("Def/TestTag", hed_schema=self.hed_schema)
@@ -47,21 +47,21 @@ class Test(unittest.TestCase):
         self.assertEqual(len(string2.get_all_tags()), 3)
         self.assertEqual(len(comb_string.get_all_tags()), 4)
         tags = comb_string.find_tags(["Object".lower()], include_groups=0)
-        comb_string.replace_tag(tags[0], copy.copy(new_contents))
+        comb_string.replace(tags[0], copy.copy(new_contents))
 
         self.assertEqual(len(string1.get_all_tags()), 1)
         self.assertEqual(len(string2.get_all_tags()), 3)
         self.assertEqual(len(comb_string.get_all_tags()), 4)
 
         tags = comb_string.find_tags(["Event".lower()], include_groups=0)
-        comb_string.replace_tag(tags[0], copy.copy(new_contents))
+        comb_string.replace(tags[0], copy.copy(new_contents))
         self.assertEqual(len(string1.get_all_tags()), 1)
         self.assertEqual(len(string2.get_all_tags()), 3)
         self.assertEqual(len(comb_string.get_all_tags()), 4)
 
         tag_group = comb_string.find_tags(["Event".lower()], recursive=True, include_groups=2)
         tag, group = tag_group[0][0], tag_group[0][1]
-        group.replace_tag(tag, copy.copy(new_contents))
+        group.replace(tag, copy.copy(new_contents))
         self.assertEqual(len(string1.get_all_tags()), 1)
         self.assertEqual(len(string2.get_all_tags()), 3)
         self.assertEqual(len(comb_string.get_all_tags()), 4)

--- a/tests/models/test_onset_mapper.py
+++ b/tests/models/test_onset_mapper.py
@@ -2,7 +2,7 @@ import unittest
 import os
 
 from hed.errors import ErrorHandler, OnsetErrors, ErrorContext, ValidationErrors
-from hed.models import DefinitionMapper, HedString, OnsetMapper, DefDict
+from hed.models import DefMapper, HedString, OnsetMapper, DefinitionDict
 from hed import schema
 from hed.validator import HedValidator
 
@@ -57,10 +57,10 @@ class Test(TestHedBase):
             self.assertCountEqual(onset_issues, issues)
 
     def test_basic_onset_errors(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
 
         test_strings = [
@@ -107,10 +107,10 @@ class Test(TestHedBase):
         self._test_issues_base(test_strings, test_issues, expected_context, [onset_mapper])
 
     def test_basic_onset_errors_with_def_mapper(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
         hed_ops = [def_mapper, onset_mapper]
 
@@ -159,12 +159,12 @@ class Test(TestHedBase):
         self._test_issues_base(test_strings, test_issues, expected_context, hed_ops, expand_defs=False)
 
     def test_basic_onset_errors_expanded(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
         def_string = HedString(self.definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
 
         test_strings = [
@@ -210,12 +210,12 @@ class Test(TestHedBase):
         self._test_issues_base(test_strings, test_issues, expected_context, [onset_mapper])
 
     def test_test_interleaving_onset_offset(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
         def_string = HedString(self.definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
 
         test_strings = [
@@ -251,10 +251,10 @@ class Test(TestHedBase):
         self._test_issues_base(test_strings, test_issues, expected_context, [onset_mapper])
 
     def test_onset_with_defs_in_them(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
 
         test_strings = [
@@ -272,12 +272,12 @@ class Test(TestHedBase):
         self._test_issues_base(test_strings, test_issues, expected_context, [onset_mapper])
 
     def test_onset_multiple_or_misplaced_errors(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
         def_string = HedString(self.definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
         hed_validator = HedValidator(hed_schema=self.hed_schema)
         hed_ops = [hed_validator, def_mapper, onset_mapper]
@@ -314,12 +314,12 @@ class Test(TestHedBase):
         self._test_issues_no_context(test_strings, test_issues, hed_validator)
 
     def test_onset_multiple_or_misplaced_errors_no_validator(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
         def_string = HedString(self.definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
         hed_ops = [def_mapper, onset_mapper]
 
@@ -356,12 +356,12 @@ class Test(TestHedBase):
         self._test_issues_no_context(test_strings, test_issues, [hed_ops[1]])
 
     def test_onset_two_in_one_line(self):
-        def_dict = DefDict()
+        def_dict = DefinitionDict()
         def_string = HedString(self.placeholder_definition_string)
         def_string.validate(def_dict)
         def_string = HedString(self.definition_string)
         def_string.validate(def_dict)
-        def_mapper = DefinitionMapper(def_dict)
+        def_mapper = DefMapper(def_dict)
         onset_mapper = OnsetMapper(def_mapper)
 
         test_strings = [

--- a/tests/models/test_sidecar.py
+++ b/tests/models/test_sidecar.py
@@ -6,7 +6,7 @@ from hed.errors import HedFileError
 from hed.models import ColumnMetadata, HedString, Sidecar
 from hed.validator import HedValidator
 from hed import schema
-from hed.models import DefDict
+from hed.models import DefinitionDict
 
 
 class Test(unittest.TestCase):
@@ -104,7 +104,7 @@ class Test(unittest.TestCase):
         self.assertEqual(len(validation_issues), 1)
 
         hed_string = HedString("(Definition/JsonFileDef/#, (Item/JsonDef1/#,Item/JsonDef1))")
-        extra_def_dict = DefDict()
+        extra_def_dict = DefinitionDict()
         hed_string.validate(extra_def_dict)
 
         validation_issues = self.json_without_definitions_sidecar.validate_entries(validator, check_for_warnings=True,

--- a/tests/models/tests_expression_parser.py
+++ b/tests/models/tests_expression_parser.py
@@ -5,7 +5,7 @@ import os
 from hed import schema
 
 
-class test_parser(unittest.TestCase):
+class TestParser(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.base_data_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../data/')
@@ -15,13 +15,13 @@ class test_parser(unittest.TestCase):
     def base_test(self, parse_expr, search_strings):
         expression = TagExpressionParser(parse_expr)
 
-        print(f"Search Pattern: {expression._org_string}")
+        # print(f"Search Pattern: {expression._org_string}")
         for string, expected_result in search_strings.items():
             hed_string = HedStringFrozen(string, self.hed_schema)
             result = expression.search_hed_string(hed_string)
-            print(f"\tSearching string '{str(hed_string)}'")
-            if result:
-                print(f"\t\tFound as group(s) {str([str(r) for r in result])}")
+            # print(f"\tSearching string '{str(hed_string)}'")
+            # if result:
+            #    print(f"\t\tFound as group(s) {str([str(r) for r in result])}")
             self.assertEqual(bool(result), expected_result)
 
     def test_broken_search_strings(self):
@@ -83,7 +83,7 @@ class test_parser(unittest.TestCase):
             "(A, B, (C, D))": True,
             "(A, B, ((C, D)))": False,
             "(E, F, (A, B, (C, D)))": True,
-            "(A, B, (E, F, (C, D)))": False, # Todo: Should this be True?  [[c]] isn't directly inside an a group.
+            "(A, B, (E, F, (C, D)))": False,  # TODO: Should this be True?  [[c]] isn't directly inside an a group.
         }
         self.base_test("[[a, [[c]] ]]", test_strings)
 
@@ -113,7 +113,7 @@ class test_parser(unittest.TestCase):
             "(A, D)": False,
             "((A), (D))": True,
             "((A), ((D)))": True,
-            "((A, D))": True,  # todo: should this be true?  Probably not.
+            "((A, D))": True,  # TODO: should this be true?  Probably not.
         }
         self.base_test("[[ [a], [d] ]]", test_strings)
 
@@ -122,7 +122,7 @@ class test_parser(unittest.TestCase):
             "(A, D)": False,
             "((A), (D))": True,
             "((A), ((D)))": False,
-            "((A, D))": True,  # todo: should this be true?  Probably not.
+            "((A, D))": True,  # TODO: should this be true?  Probably not.
         }
         self.base_test("[[ [[a]], [[d]] ]]", test_strings)
 
@@ -145,13 +145,12 @@ class test_parser(unittest.TestCase):
         }
         self.base_test("[[ [[~a]] ]]", test_strings)
 
-
     def test_exact_group_split_or_negation_dual(self):
         test_strings = {
             "(A, B)": False,
             "((A), (B))": False,
             "((A))": False,
-            "((A), ((B)))": True, # todo: should all result groups have to have tags?.  this is true because of ((B)) group with no tags
+            "((A), ((B)))": True,  # TODO: must all result groups have tags?  True because of ((B)) group with no tags.
             "((A, B))": False,
             "((A), (C))": True,
             "((A), (B, C))": False,
@@ -185,7 +184,7 @@ class test_parser(unittest.TestCase):
         }
         self.base_test("[[ [[~(a or b)]] ]] and [[D or ~F]]", test_strings)
 
-    # Todo: Should this work, and what should it mean?
+    # TODO: Should this work, and what should it mean?
     # Right now this is always true, since there is at least one group without ", (a)" in every string.
     def test_exact_group_negation(self):
         test_strings = {
@@ -216,7 +215,7 @@ class test_parser(unittest.TestCase):
             "(A, B, ((C, D)))": False,
             "(E, F, (A, B, (C, D)))": True,
             "((A, B), (C, D))": True,
-            "((A, B, C, D))": True, # todo: should this be true?  Probably not.
+            "((A, B, C, D))": True,  # TODO: should this be true?  Probably not.
         }
         self.base_test("[[ [a, b], [c, d] ]]", test_strings)
 
@@ -241,7 +240,6 @@ class test_parser(unittest.TestCase):
             "(B, (C)), (A, B, (C))": True
         }
         self.base_test("[a, b, [c] ]", test_strings)
-
 
     def test_containing_group(self):
         test_strings = {
@@ -290,62 +288,61 @@ class test_parser(unittest.TestCase):
 
     def test_and_or(self):
         test_strings = {
-            "A":False,
-            "B":False,
-            "C":True,
-            "A, B":True,
-            "A, C":True,
+            "A": False,
+            "B": False,
+            "C": True,
+            "A, B": True,
+            "A, C": True,
             "B, C": True
         }
         self.base_test("a and b or c", test_strings)
 
         test_strings = {
-            "A":False,
-            "B":False,
-            "C":True,
-            "A, B":True,
-            "A, C":True,
+            "A": False,
+            "B": False,
+            "C": True,
+            "A, B": True,
+            "A, C": True,
             "B, C": True
         }
         self.base_test("(a and b) or c", test_strings)
 
         test_strings = {
-            "A":False,
-            "B":False,
-            "C":False,
-            "A, B":True,
-            "A, C":True,
+            "A": False,
+            "B": False,
+            "C": False,
+            "A, B": True,
+            "A, C": True,
             "B, C": False
         }
         self.base_test("a and (b or c)", test_strings)
 
-
         test_strings = {
-            "A":False,
-            "B":False,
-            "C":False,
-            "A, B":False,
-            "A, C":True,
+            "A": False,
+            "B": False,
+            "C": False,
+            "A, B": False,
+            "A, C": True,
             "B, C": True
         }
         self.base_test("a or b and c", test_strings)
 
         test_strings = {
-            "A":True,
-            "B":False,
-            "C":False,
-            "A, B":True,
-            "A, C":True,
+            "A": True,
+            "B": False,
+            "C": False,
+            "A, B": True,
+            "A, C": True,
             "B, C": True
         }
         self.base_test("a or (b and c)", test_strings)
 
         test_strings = {
-            "A":False,
-            "B":False,
-            "C":False,
-            "A, B":False,
-            "A, C":True,
+            "A": False,
+            "B": False,
+            "C": False,
+            "A, B": False,
+            "A, C": True,
             "B, C": True
         }
         self.base_test("(a or b) and c", test_strings)
@@ -376,4 +373,3 @@ class test_parser(unittest.TestCase):
         self.assertEqual(bool(expression.search_hed_string(hed_string)), True)
         hed_string = HedStringFrozen("A, C")
         self.assertEqual(bool(expression.search_hed_string(hed_string)), False)
-

--- a/tests/tools/annotation/test_annotation_util.py
+++ b/tests/tools/annotation/test_annotation_util.py
@@ -173,6 +173,21 @@ class Test(unittest.TestCase):
         self.assertIsInstance(entry2['HED'], str,
                               "generate_sidecar_entry HED entry should be str when no column values")
 
+    def test_generate_sidecar_entry_non_letters(self):
+        entry1 = generate_sidecar_entry('my !#$-123_10', column_values=['apple 1', '@banana', 'grape%cherry&'])
+        self.assertIsInstance(entry1, dict,
+                              "generate_sidecar_entry is a dictionary when column values and special chars.")
+        self.assertIn('HED', entry1,
+                      "generate_sidecar_entry has a HED key when column values and special chars")
+        hed_entry1 = entry1['HED']
+        self.assertEqual(hed_entry1['apple 1'], '(Label/my_-123_10, Label/apple_1)',
+                         "generate_sidecar_entry HED entry should convert labels correctly when column values")
+        entry2 = generate_sidecar_entry('my !#$-123_10')
+        self.assertIsInstance(entry2, dict,
+                              "generate_sidecar_entry is a dictionary when no column values and special chars.")
+        self.assertEqual(entry2['HED'], '(Label/my_-123_10, Label/#)',
+                         "generate_sidecar_entry HED entry has correct label when no column values and special chars.")
+
     def test_hed_to_df(self):
         df1a = hed_to_df(self.sidecar1a, col_names=None)
         self.assertIsInstance(df1a, DataFrame)

--- a/tests/validator/test_hed_validator.py
+++ b/tests/validator/test_hed_validator.py
@@ -4,7 +4,7 @@ import os
 #from hed import
 from hed.errors import ErrorContext
 from hed import schema
-from hed.models import DefinitionMapper, HedString, HedInput, EventsInput, Sidecar
+from hed.models import DefMapper, HedString, HedInput, EventsInput, Sidecar
 from hed.validator import HedValidator
 
 
@@ -156,7 +156,7 @@ class Test(unittest.TestCase):
     def test_org_tag_missing(self):
         test_string_obj = HedString("Event, Item/NotItem")
         removed_tag = test_string_obj.tags()[0]
-        test_string_obj.remove_groups([removed_tag])
+        test_string_obj.remove([removed_tag])
         from hed import HedTag
         source_span = test_string_obj._get_org_span(removed_tag)
         self.assertEqual(source_span, (0, 5))
@@ -169,7 +169,7 @@ class Test(unittest.TestCase):
                                    '../data/schema_test_data/HED8.0.0.mediawiki')
         hed_schema = schema.load_schema(schema_path)
         validator = HedValidator(hed_schema=hed_schema)
-        def_mapper = DefinitionMapper()
+        def_mapper = DefMapper()
         string_with_def = \
             '(Definition/TestDefPlaceholder/#,(Item/TestDef1/#,Item/TestDef2)), def/TestDefPlaceholder/2471'
         test_string = HedString(string_with_def)
@@ -181,7 +181,7 @@ class Test(unittest.TestCase):
                                    '../data/schema_test_data/HED8.0.0.mediawiki')
         hed_schema = schema.load_schema(schema_path)
         validator = HedValidator(hed_schema=hed_schema)
-        def_mapper = DefinitionMapper()
+        def_mapper = DefMapper()
         string_with_def = \
             '(Definition/TestDef,(Item/TestDef1,Item/TestDef1))'
         test_string = HedString(string_with_def)


### PR DESCRIPTION
The generate_sidecar_entry did not create json sidecars that could be validated when there were categorical column values that were used in multiple columns (like 0, 1, 2)...   The generation was updated to include the column name in the dummy HED tagging.