### PR TITLE
Make rows always ignore column header

### DIFF
--- a/hed/errors/error_messages.py
+++ b/hed/errors/error_messages.py
@@ -9,11 +9,6 @@ from hed.errors.error_types import ValidationErrors, SchemaErrors, \
     SidecarErrors, SchemaWarnings, ErrorSeverity, DefinitionErrors, OnsetErrors
 
 
-@hed_error(DefinitionErrors.INVALID_DEFINITION_EXTENSION, actual_code=ValidationErrors.HED_DEFINITION_INVALID)
-def def_error_invalid_def_extension(def_name):
-    return f"Term '{def_name}' has an invalid extension.  Definitions can only have one term.", {}
-
-
 @hed_tag_error(ValidationErrors.HED_UNITS_INVALID)
 def val_error_invalid_unit(tag, unit_class_units):
     units_string = ','.join(sorted(unit_class_units))
@@ -285,6 +280,12 @@ def def_error_duplicate_definition(def_name):
 @hed_error(DefinitionErrors.TAG_IN_SCHEMA, actual_code=ValidationErrors.HED_DEFINITION_INVALID)
 def def_error_tag_already_in_schema(def_name):
     return f"Term '{def_name}' already used as term in schema and cannot be re-used as a definition.", {}
+
+
+@hed_error(DefinitionErrors.INVALID_DEFINITION_EXTENSION, actual_code=ValidationErrors.HED_DEFINITION_INVALID)
+def def_error_invalid_def_extension(def_name):
+    return f"Term '{def_name}' has an invalid extension.  Definitions can only have one term.", {}
+
 
 
 @hed_tag_error(OnsetErrors.ONSET_DEF_UNMATCHED, actual_code=ValidationErrors.HED_ONSET_OFFSET_ERROR)

--- a/hed/errors/error_reporter.py
+++ b/hed/errors/error_reporter.py
@@ -300,18 +300,18 @@ class ErrorHandler:
         """
         error_func = error_functions.get(error_type)
         if not error_func:
-            error_object_list = ErrorHandler.val_error_unknown(*args, **kwargs)
-            error_object_list[0]['code'] = error_type
-            ErrorHandler._add_context_to_errors(error_object_list[0], error_context)
-            return error_object_list
+            error_object = ErrorHandler.val_error_unknown(*args, **kwargs)
+            error_object['code'] = error_type
+            ErrorHandler._add_context_to_errors(error_object, error_context)
+            return [error_object]
 
-        error_object_list = error_func(*args, **kwargs)
+        error_object = error_func(*args, **kwargs)
         if actual_error:
-            error_object_list[0]['code'] = actual_error
+            error_object['code'] = actual_error
 
-        ErrorHandler._add_context_to_errors(error_object_list[0], error_context)
-        ErrorHandler._update_error_with_char_pos(error_object_list[0])
-        return error_object_list
+        ErrorHandler._add_context_to_errors(error_object, error_context)
+        ErrorHandler._update_error_with_char_pos(error_object)
+        return [error_object]
 
     @staticmethod
     def _add_context_to_errors(error_object, error_context_to_add):

--- a/hed/models/base_input.py
+++ b/hed/models/base_input.py
@@ -296,8 +296,6 @@ class BaseInput:
                                                       error_handler=error_handler, **kwargs)
 
         start_at_one = 1
-        if self._has_column_names:
-            start_at_one += 1
 
         # Iter tuples is ~ 25% faster compared to iterrows in our use case
         for row_number, text_file_row in enumerate(self._dataframe.itertuples(index=False)):
@@ -340,8 +338,6 @@ class BaseInput:
                                            remove_definitions=remove_definitions, error_handler=error_handler)
 
         adj_row_number = 1
-        if self._has_column_names:
-            adj_row_number += 1
 
         text_file_row = self._dataframe.iloc[row_number - adj_row_number]
         return self._expand_row_internal(text_file_row, tag_funcs, None, error_handler=error_handler,
@@ -372,8 +368,6 @@ class BaseInput:
 
         new_text = new_string_obj.get_as_form(tag_form, transform_func)
         adj_row_number = 1
-        if self._has_column_names:
-            adj_row_number += 1
         self._dataframe.iloc[row_number - adj_row_number, column_number - 1] = new_text
 
     def get_worksheet(self, worksheet_name=None):

--- a/hed/models/column_metadata.py
+++ b/hed/models/column_metadata.py
@@ -413,7 +413,7 @@ class ColumnMetadata:
             return []
 
         # Make a copy without definitions to check placeholder count.
-        hed_string_copy = copy.copy(hed_string)
+        hed_string_copy = copy.deepcopy(hed_string)
         hed_string_copy.remove_definitions()
 
         if hed_string_copy.lower().count("#") != expected_pound_sign_count:

--- a/hed/models/definition_dict.py
+++ b/hed/models/definition_dict.py
@@ -23,8 +23,6 @@ class DefinitionEntry:
         """
         self.name = name
         self.contents = contents
-        if contents:
-            contents.cascade_mutable(False)
         self.takes_value = takes_value
         self.source_context = source_context
         self.tag_dict = {}
@@ -56,12 +54,10 @@ class DefinitionEntry:
         if self.contents:
             output_group = self.contents
             if placeholder_value:
-                # todo: This part could be optimized more
+                output_group = copy.deepcopy(self.contents)
                 placeholder_tag = output_group.find_placeholder_tag()
                 if not placeholder_tag:
                     raise ValueError("Internal error related to placeholders in definition mapping")
-                output_group = copy.copy(self.contents)
-                placeholder_tag = output_group.make_tag_mutable(placeholder_tag)
                 name = f"{name}/{placeholder_value}"
                 placeholder_tag.replace_placeholder(placeholder_value)
 

--- a/hed/models/definition_dict.py
+++ b/hed/models/definition_dict.py
@@ -22,6 +22,8 @@ class DefinitionEntry:
             source_context (dict): Info about where this definition was declared.
         """
         self.name = name
+        if contents:
+            contents = contents.copy()
         self.contents = contents
         self.takes_value = takes_value
         self.source_context = source_context

--- a/hed/models/expression_parser.py
+++ b/hed/models/expression_parser.py
@@ -227,7 +227,7 @@ class TagExpressionParser:
 
     def _tokenize(self, expression_string):
         grouping_re = r"\[\[|\[|,|\]\]|\]"
-        paren_re = "\)|\(|~"
+        paren_re = r"\)|\(|~"
         word_re = r"\band\b|\bor\b|[_\-a-zA-Z0-9/.^#]+"
         re_string = fr"({grouping_re}|{paren_re}|{word_re})"
         token_re = re.compile(re_string)

--- a/hed/models/hed_group.py
+++ b/hed/models/hed_group.py
@@ -1,6 +1,6 @@
 from hed.models.hed_tag import HedTag
-import copy
 from hed.models.hed_group_base import HedGroupBase
+import copy
 
 
 class HedGroup(HedGroupBase):
@@ -23,34 +23,11 @@ class HedGroup(HedGroupBase):
         super().__init__(hed_string=hed_string, startpos=startpos, endpos=endpos)
         if contents:
             self._children = contents
+            for child in self._children:
+                child._parent = self
         else:
             self._children = []
         self._original_children = self._children
-        self.mutable = True  # If False, this group is potentially referenced in other places and should not be altered
-
-    def __eq__(self, other):
-        """ Test if the same object or a HedGroup with same contents.
-
-            Args:
-                other (object):  Any object.
-
-            Returns:
-                bool:  True if other is the same as this HedGroup or is a HedGroup with the same contents.
-
-        TODO: check to see if can be moved to HedGroupBase.
-
-        """
-
-        if self is other:
-            return True
-        if not isinstance(other, HedGroup):
-            return False
-
-        if self.children != other.children:
-            return False
-        if self.is_group != other.is_group:
-            return False
-        return True
 
     def append(self, tag_or_group):
         """ Add a tag or group to this group.
@@ -62,9 +39,7 @@ class HedGroup(HedGroupBase):
             ValueError: If a HedGroupFrozen.
 
         """
-        if not self.mutable:
-            raise ValueError("Trying to alter immutable group")
-
+        tag_or_group._parent = self
         self._children.append(tag_or_group)
 
     def check_if_in_original(self, tag_or_group):
@@ -96,16 +71,9 @@ class HedGroup(HedGroupBase):
         """ Replace an existing tag or group in the group with a new tag, list, or group.
 
         Args:
-            item_to_replace (HedTag or HedGroup): The item to  replace must exist or this will raise an error.
+            item_to_replace (HedTag or HedGroup): The item to replace must exist or this will raise an error.
             new_contents (HedTag, HedGroup or list of HedTag and/or HedGroup): Replacement contents.
-
-        Raises:
-            ValueError:  If this HedGroup is not mutable.
-
         """
-        if not self.mutable:
-            raise ValueError("Trying to alter immutable group")
-
         if self._original_children is self._children:
             self._original_children = self._children.copy()
 
@@ -115,40 +83,7 @@ class HedGroup(HedGroupBase):
                 replace_index = i
                 break
         self._children[replace_index] = new_contents
-
-    def __copy__(self):
-        """ Return a shallow mutable copy with a new _children list, rather than the same list.
-
-        Returns:
-            HedGroup:  A mutable shallow copy of this HedGroup.
-
-        Notes:
-            The child HedTags and HedGroups are the same objects (similar to list copy).
-            This operation is mainly used for handling definitions.
-
-        TODO: Check to see if can be moved to HedGroupBase.
-
-        """
-        cls = self.__class__
-        result = cls.__new__(cls)
-        result.__dict__.update(self.__dict__)
-        result._children = self._children.copy()
-        result.mutable = True
-        return result
-
-    def cascade_mutable(self, value):
-        """ Set the mutable property for all child tags and groups.
-
-        Args:
-            value (bool):  True if all should be mutable, False if not.
-
-        """
-        self.mutable = value
-        for child in self._children:
-            if isinstance(child, HedGroup):
-                child.cascade_mutable(value)
-            else:
-                child.mutable = value
+        new_contents._parent = self
 
     def remove(self, items_to_remove):
         """ Remove any tags/groups in items_to_remove found in this HedGroup.
@@ -159,7 +94,6 @@ class HedGroup(HedGroupBase):
         Notes:
             Any groups that become empty will also be pruned.
             Identity, not equivalence is used in determining whether or not to remove.
-            This cannot be a non-mutable HedGroup.
 
         """
         all_groups = self.get_all_groups()
@@ -171,18 +105,12 @@ class HedGroup(HedGroupBase):
         Args:
             items_to_remove (list):  List of HedGroups and/or HedTags to remove.
             all_groups (list):   List of HedGroups.
-
-        Raise:
-            ValueError: If an attempt to remove a child from a non-mutable group.
-
         """
         empty_groups = []
         for remove_child in items_to_remove:
             for group in all_groups:
                 # only proceed if we have an EXACT match for this child
                 if any(remove_child is child for child in group._children):
-                    if not group.mutable:
-                        raise ValueError("Trying to alter immutable group")
                     if group._original_children is group._children:
                         group._original_children = group._children.copy()
 
@@ -194,32 +122,6 @@ class HedGroup(HedGroupBase):
 
         if empty_groups:
             self.remove(empty_groups)
-
-    def make_tag_mutable(self, tag):
-        """ Replace the given tag in this group with a tag that can be altered and return new version.
-
-        Args:
-            tag (HedTag): The tag to make mutable.
-
-        Returns:
-            HedTag: A mutable new copy of the tag, or the old mutable one.
-
-        Raises:
-            ValueError:  If this HedGroup is not already mutable, the operation fails.
-
-        Notes:
-            This method is more or less exclusively for definition expansion.
-
-        """
-        if not self.mutable:
-            raise ValueError("Trying to alter immutable group")
-
-        if not tag.mutable:
-            tag_copy = copy.copy(tag)
-            tag_copy.mutable = True
-            self.replace(tag, tag_copy)
-            return tag_copy
-        return tag
 
     def get_frozen(self):
         """ Returns a frozen (non-mutable) copy of this HedGroup.
@@ -251,6 +153,8 @@ class HedGroupFrozen(HedGroupBase):
                 If a list, may be a mixture of HedTags and HedGroups. Use the hed_string parameter as the source.
             hed_string (str or None): If contents is a list, this is the raw string the contents came from.
 
+        Notes
+            This makes a complete copy of the HedString.
         """
         if isinstance(contents, HedGroupBase):
             span = contents.span
@@ -267,9 +171,9 @@ class HedGroupFrozen(HedGroupBase):
 
         super().__init__(hed_string=hed_string, startpos=span[0], endpos=span[1])
         if contents is not None:
-            self._children = frozenset(child if not isinstance(child, HedGroupBase)
+            self._children = frozenset(copy.copy(child) if not isinstance(child, HedGroupBase)
                                        else HedGroupFrozen(child) for child in contents)
-            for child in self.groups():
+            for child in self._children:
                 child._parent = self
         else:
             self._children = None
@@ -278,24 +182,6 @@ class HedGroupFrozen(HedGroupBase):
     def __hash__(self):
         """ Get a hash of this HedFrozenGroup."""
         return hash((self._children, self.is_group))
-
-    def __eq__(self, other):
-        """
-        TODO:  Put in the HedGroupBase
-
-        """
-        if self is other:
-            return True
-
-        if not isinstance(other, HedGroupFrozen):
-            return False
-
-        if self._children != other._children:
-            return False
-
-        if self.is_group != other.is_group:
-            return False
-        return True
 
     def get_all_tags(self):
         """ Return all the HedTags in this group, including descendants.

--- a/hed/models/hed_group_base.py
+++ b/hed/models/hed_group_base.py
@@ -1,3 +1,5 @@
+import copy
+
 from hed.models.hed_tag import HedTag
 
 
@@ -23,6 +25,19 @@ class HedGroupBase:
 
     def __copy__(self):
         raise ValueError("Cannot make shallow copies of HedGroups")
+
+    def copy(self):
+        """
+            Return a deep copy of this group, with the parent pointer removed.
+
+        Returns:
+            copied_group (HedGroupBase): The copied group
+        """
+        save_parent = self._parent
+        self._parent = None
+        return_copy = copy.deepcopy(self)
+        self._parent = save_parent
+        return return_copy
 
     @property
     def children(self):

--- a/hed/models/hed_group_base.py
+++ b/hed/models/hed_group_base.py
@@ -16,10 +16,13 @@ class HedGroupBase:
         self._startpos = startpos
         self._endpos = endpos
         self._hed_string = hed_string
-        self.mutable = True  # If False, this group is potentially referenced in other places and should not be altered
+        self._parent = None
 
         # placeholder just to make IDE not complain
         self._children = None
+
+    def __copy__(self):
+        raise ValueError("Cannot make shallow copies of HedGroups")
 
     @property
     def children(self):
@@ -203,6 +206,23 @@ class HedGroupBase:
 
     def __bool__(self):
         return bool(self._children)
+
+    def __eq__(self, other):
+        """
+
+        """
+        if self is other:
+            return True
+
+        if not isinstance(other, HedGroupBase):
+            return False
+
+        if self.children != other.children:
+            return False
+
+        if self.is_group != other.is_group:
+            return False
+        return True
 
     def find_tags(self, search_tags, recursive=False, include_groups=2):
         """ Find the search tags and their containing groups that are in this group.

--- a/hed/models/hed_string.py
+++ b/hed/models/hed_string.py
@@ -32,7 +32,6 @@ class HedString(HedGroup):
             contents = self.split_into_groups(hed_string, hed_schema)
         except ValueError:
             contents = []
-
         super().__init__(hed_string, contents=contents, startpos=0, endpos=len(hed_string))
 
     @property

--- a/hed/models/hed_string_comb.py
+++ b/hed/models/hed_string_comb.py
@@ -20,6 +20,11 @@ class HedStringComb(HedString):
         """
         super().__init__("")
         self._children = list(hed_string for hed_string in hed_string_obj_list if hed_string is not None)
+        # Update the direct children to point to this combined string, rather than their original string
+        for child in self._children:
+            for sub_child in child.children:
+                sub_child._parent = self
+
         self._original_children = self._children
 
     def get_original_hed_string(self):
@@ -75,9 +80,6 @@ class HedStringComb(HedString):
         new_contents : HedTag or HedGroup or [HedTag or HedGroup]
             What to replace the tag with.
         """
-        if not self.mutable:
-            raise ValueError("Trying to alter immutable group")
-
         # this needs to pass the tag off to the appropriate group
         replace_sub_string = None
         for sub_string in self._children:
@@ -102,7 +104,6 @@ class HedStringComb(HedString):
         result._startpos, result._endpos = self.span
         result._hed_string = self.get_original_hed_string()
         result._children = self.children.copy()
-        result.mutable = True
         return result
 
     def _get_org_span(self, tag_or_group):

--- a/hed/models/hed_tag.py
+++ b/hed/models/hed_tag.py
@@ -39,10 +39,7 @@ class HedTag:
         self._schema_entry = None
 
         self._extension_value = ""
-
-        # Note this only keeps track of tags also used in definitions.  You should also not
-        # alter any tags used in a HedGroupFrozen
-        self.mutable = True
+        self._parent = None
 
         if hed_schema:
             self.convert_to_canonical_forms(hed_schema)
@@ -120,8 +117,6 @@ class HedTag:
         -------
 
         """
-        if not self.mutable:
-            raise ValueError("Trying to alter immutable tag")
         if self._schema_entry:
             if self._schema:
                 tag_entry = self._schema.get_tag_entry(new_tag_val, library_prefix=self.library_prefix)
@@ -201,8 +196,6 @@ class HedTag:
         new_tag_val : str
             New (implicitly long form) of tag to set
         """
-        if not self.mutable:
-            raise ValueError("Trying to alter immutable tag")
 
         if self._schema_entry:
             raise ValueError("Can only edit tags before calculating canonical forms. " +
@@ -311,9 +304,6 @@ class HedTag:
                 Prefix will be added.
 
         """
-
-        # if not self.mutable:
-        #     raise ValueError("Trying to alter immutable tag")
 
         checking_prefix = required_prefix
         while checking_prefix:
@@ -664,9 +654,6 @@ class HedTag:
         placeholder_value : str
             Value to replace placeholder with.
         """
-        # if not self.mutable:
-        #     raise ValueError("Trying to alter immutable tag")
-
         if "#" in self.org_tag:
             if self._schema_entry:
                 self._extension_value = self._extension_value.replace("#", placeholder_value)

--- a/tests/models/test_column_mapper.py
+++ b/tests/models/test_column_mapper.py
@@ -3,7 +3,7 @@ import os
 
 from hed.models import ColumnMapper, ColumnType, ColumnMetadata, HedString, model_constants
 from hed.schema import load_schema
-
+from hed import HedFileError
 
 class Test(unittest.TestCase):
     schema_file = '../data/schema_test_data/HED8.0.0t.xml'
@@ -206,7 +206,6 @@ class Test(unittest.TestCase):
             expanded_row = column_mapper.expand_row_tags([test_string])
             prepended_hed_string = expanded_row[model_constants.COLUMN_TO_HED_TAGS][1]
             self.assertEqual(expected_result, str(prepended_hed_string))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/models/test_sidecar.py
+++ b/tests/models/test_sidecar.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import io
 
-from hed.errors import HedFileError
+from hed.errors import HedFileError, ValidationErrors
 from hed.models import ColumnMetadata, HedString, Sidecar
 from hed.validator import HedValidator
 from hed import schema
@@ -110,6 +110,14 @@ class Test(unittest.TestCase):
         validation_issues = self.json_without_definitions_sidecar.validate_entries(validator, check_for_warnings=True,
                                                                                    extra_def_dicts=extra_def_dict)
         self.assertEqual(len(validation_issues), 0)
+
+    def test_duplicate_def(self):
+        sidecar = self.json_def_sidecar
+        def_dicts = sidecar.get_def_dicts()
+
+        issues = sidecar.validate_entries(extra_def_dicts=def_dicts)
+        self.assertEqual(len(issues), 5)
+        self.assertTrue(issues[0]['code'], ValidationErrors.HED_DEFINITION_INVALID)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
HedGroups/tags now know their parent group.  HedGroups cannot be shallow copied.
Expression Search now works on HedString
DefMapper will flag duplicate definitions as issues