### PR TITLE
Update Input/Sidecar classes to take schema

### DIFF
--- a/hed/models/hed_ops.py
+++ b/hed/models/hed_ops.py
@@ -18,13 +18,14 @@ default_arguments = {
 }
 
 
-def translate_ops(hed_ops, split_ops=False, **kwargs):
+def translate_ops(hed_ops, split_ops=False, hed_schema=None, **kwargs):
     """ Return functions to apply to a hed string object.
 
     Args:
         hed_ops (list): A list of func or HedOps or HedSchema to apply to hed strings.
         split_ops (bool): If true, will split the operations into separate lists of tag and string operations.
-        kwargs (dict):  An optional dictionary of name-value pairs representing parameters passed to each HedOps
+        hed_schema(HedSchema or None): The schema to use by default in identifying tags
+        kwargs (kwargs):  An optional dictionary of name-value pairs representing parameters passed to each HedOps
 
     Returns:
         list or tuple: A list of functions to apply or a tuple containing separate lists of tag and string ops.
@@ -68,7 +69,7 @@ def translate_ops(hed_ops, split_ops=False, **kwargs):
 
     # Make sure the first column operation is a convert to forms, if we don't have one.
     if not _func_in_list(HedString.convert_to_canonical_forms, tag_funcs):
-        tag_funcs.insert(0, partial(HedString.convert_to_canonical_forms, hed_schema=None))
+        tag_funcs.insert(0, partial(HedString.convert_to_canonical_forms, hed_schema=hed_schema))
 
     if split_ops:
         return tag_funcs, string_funcs
@@ -81,7 +82,7 @@ def apply_ops(hed_strings, hed_ops, **kwargs):
     Args:
         hed_strings(str, dict, list): A list/dict/str to update
         hed_ops (list or HedOps or func): A list of func or HedOps or HedSchema to apply to hed strings.
-        kwargs (dict):  An optional dictionary of name-value pairs representing parameters passed to each HedOps
+        kwargs (kwargs):  An optional dictionary of name-value pairs representing parameters passed to each HedOps
 
     Returns:
         tuple:

--- a/hed/models/sidecar.py
+++ b/hed/models/sidecar.py
@@ -14,17 +14,17 @@ class Sidecar(SidecarBase):
 
     """
 
-    def __init__(self, files, name=None):
+    def __init__(self, files, name=None, hed_schema=None):
         """ Construct a Sidecar object representing a JSON file.
 
         Args:
             files (str or FileLike or list): A string or file-like object representing a JSON file, or a list of such.
             name (str or None): Optional name identifying this sidecar, generally a filename.
-
+            hed_schema(HedSchema or None): The schema to use by default in identifying tags
         """
-        super().__init__(name)
+        super().__init__(name, hed_schema=hed_schema)
         self.loaded_dict = self.load_sidecar_files(files)
-        self.def_dict = self.extract_definitions()
+        self.def_dict = self.extract_definitions(hed_schema)
 
     @property
     def column_data(self):

--- a/hed/models/sidecar_base.py
+++ b/hed/models/sidecar_base.py
@@ -20,14 +20,15 @@ class SidecarBase:
         column_data property <- This is the only truly mandatory one
 
     """
-    def __init__(self, name=None):
+    def __init__(self, name=None, hed_schema=None):
         """ Initialize a sidecar baseclass
 
         Args:
             name (str or None): Optional name identifying this sidecar, generally a filename.
-
+            hed_schema(HedSchema or None): The schema to use by default in identifying tags
         """
         self.name = name
+        self._schema = hed_schema
         # Expected to be called in subclass after data is loaded
         # self.def_dict = self.extract_definitions()
 
@@ -110,9 +111,9 @@ class SidecarBase:
         hed_ops = self._standardize_ops(hed_ops)
         if expand_defs or remove_definitions:
             self._add_definition_mapper(hed_ops, extra_def_dicts)
-        tag_funcs = translate_ops(hed_ops, error_handler=error_handler, expand_defs=expand_defs,
-                                  allow_placeholders=allow_placeholders, remove_definitions=remove_definitions,
-                                  **kwargs)
+        tag_funcs = translate_ops(hed_ops, hed_schema=self._schema, error_handler=error_handler,
+                                  expand_defs=expand_defs, allow_placeholders=allow_placeholders,
+                                  remove_definitions=remove_definitions, **kwargs)
 
         return self._hed_string_iter(tag_funcs, error_handler)
 
@@ -217,12 +218,12 @@ class SidecarBase:
             error_handler.pop_error_context()
         return all_validation_issues
 
-    def extract_definitions(self, error_handler=None):
+    def extract_definitions(self, hed_schema=None, error_handler=None):
         """ Gather and validate definitions in metadata.
 
         Args:
             error_handler (ErrorHandler): The error handler to use for context, uses a default one if None.
-
+            hed_schema(HedSchema or None): The schema to used to identify tags
         Returns:
             DefinitionDict: Contains all the definitions located in the column.
             issues: List of issues encountered in extracting the definitions. Each issue is a dictionary.
@@ -232,6 +233,7 @@ class SidecarBase:
             error_handler = ErrorHandler()
         new_def_dict = DefinitionDict()
         hed_ops = []
+        hed_ops.append(hed_schema)
         hed_ops.append(new_def_dict)
 
         all_issues = []

--- a/hed/models/spreadsheet_input.py
+++ b/hed/models/spreadsheet_input.py
@@ -8,7 +8,7 @@ class SpreadsheetInput(BaseInput):
 
     def __init__(self, file=None, file_type=None, worksheet_name=None, tag_columns=None,
                  has_column_names=True, column_prefix_dictionary=None,
-                 def_dicts=None, name=None):
+                 def_dicts=None, name=None, hed_schema=None):
         """Constructor for the SpreadsheetInput class.
 
         Args:
@@ -23,7 +23,7 @@ class SpreadsheetInput(BaseInput):
             column_prefix_dictionary (dict): A dictionary with column number keys and prefix values.
             def_dicts (DefinitionDict or list):  A DefinitionDict or list of DefDicts containing definitions for this
                 object other than the ones extracted from the SpreadsheetInput object itself.
-
+            hed_schema(HedSchema or None): The schema to use by default in identifying tags
         Examples:
             A prefix dictionary {3: 'Label/', 5: 'Description/'} indicates that column 3 and 5 have HED tags
             that need to be prefixed by Label/ and Description/ respectively.
@@ -41,4 +41,4 @@ class SpreadsheetInput(BaseInput):
         def_mapper = DefMapper(def_dicts)
 
         super().__init__(file, file_type, worksheet_name, has_column_names, new_mapper, def_mapper=def_mapper,
-                         name=name)
+                         name=name, hed_schema=hed_schema)

--- a/hed/models/tabular_input.py
+++ b/hed/models/tabular_input.py
@@ -9,8 +9,8 @@ class TabularInput(BaseInput):
 
     HED_COLUMN_NAME = "HED"
 
-    def __init__(self, file=None, sidecar=None, extra_def_dicts=None,
-                 also_gather_defs=True, name=None):
+    def __init__(self, file=None, sidecar=None, extra_def_dicts=None, also_gather_defs=True, name=None,
+                 hed_schema=None):
         """ Constructor for the TabularInput class.
 
         Args:
@@ -23,7 +23,7 @@ class TabularInput(BaseInput):
             also_gather_defs (bool): If False, do NOT extract any definitions from column groups,
                 assume they are already in the def_dict list.
             name (str): The name to display for this file for error purposes.
-
+            hed_schema(HedSchema or None): The schema to use by default in identifying tags
         """
         if sidecar and not isinstance(sidecar, Sidecar):
             sidecar = Sidecar(sidecar)
@@ -38,7 +38,7 @@ class TabularInput(BaseInput):
 
         super().__init__(file, file_type=".tsv", worksheet_name=None, has_column_names=True, mapper=new_mapper,
                          def_mapper=def_mapper, name=name, definition_columns=definition_columns,
-                         allow_blank_names=False)
+                         allow_blank_names=False, hed_schema=hed_schema)
 
         if not self._has_column_names:
             raise ValueError("You are attempting to open a bids_old style file with no column headers provided.\n"

--- a/tests/data/model_tests/no_column_header_definition.tsv
+++ b/tests/data/model_tests/no_column_header_definition.tsv
@@ -1,2 +1,2 @@
-Geometric-object	Event, (Definition/DefTest1, (InvalidDefTag))
+Geometric-object	Event, (Definition/DefTest1, (Circle))
 Square	Item, Def/DefTest1

--- a/tests/data/model_tests/no_column_header_definition_long.tsv
+++ b/tests/data/model_tests/no_column_header_definition_long.tsv
@@ -1,2 +1,2 @@
 Item/Object/Geometric-object	Event,(Property/Organizational-property/Definition/DefTest1,(InvalidDefTag))
-Item/Object/Geometric-object/2D-shape/Rectangle/Square	Item,Property/Organizational-property/Def/DefTest1
+Item/Object/Geometric-object/2D-shape/Circle	Item,Property/Organizational-property/Def/DefTest1

--- a/tests/models/test_expression_parser.py
+++ b/tests/models/test_expression_parser.py
@@ -128,6 +128,7 @@ class TestParser(unittest.TestCase):
         test_strings = {
             "A, B, C, D": False,
             "(A, B, C, D)": False,
+            "((A, B, C, D))": True,  # todo: should this be true?  Probably not.
             "(A, B, (C, D))": False,
             "(A, B, ((C, D)))": False,
             "(E, F, (A, B, (C, D)))": False,
@@ -190,10 +191,11 @@ class TestParser(unittest.TestCase):
             "(A, B)": False,
             "((A), (B))": False,
             "((A))": False,
-            "((A), ((B)))": True,
+            "((A), ((B)))": True, # TODO: must all result groups have tags?  True because of ((B)) group with no tags.
             "((A, B))": False,
             "((A), (C))": True,
             "((A), (B, C))": False,
+            "((A), ((B), C))": True,
         }
         self.base_test("[[ [[~(a or b)]] ]]", test_strings)
 
@@ -230,6 +232,8 @@ class TestParser(unittest.TestCase):
             "((A))": False,
             "((A), ((D, B)))": True,
             "((A, D))": False,
+            "(B, (D))": True,
+            "(B)": True
         }
         self.base_test("[[ ~[[a]], b]]", test_strings)
 
@@ -253,7 +257,8 @@ class TestParser(unittest.TestCase):
             "(A, B, (C)), (A, B)": True,
             "(A, B), (A, B, (C))": True,
             "(A, B), (B, (C))": False,
-            "(B, (C)), (A, B, (C))": True
+            "(B, (C)), (A, B, (C))": True,
+            "(A, B, (A, (C)))": False
         }
         self.base_test("[[a, b, [[c]] ]]", test_strings)
 

--- a/tests/models/test_spreadsheet_input.py
+++ b/tests/models/test_spreadsheet_input.py
@@ -228,7 +228,9 @@ class Test(unittest.TestCase):
         self.assertFalse(tag._schema_entry)
 
     def test_loading_dataframe_directly(self):
-        ds = pd.read_csv("../data/model_tests/no_column_header_definition.tsv", delimiter="\t", header=None)
+        ds_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                               '../data/model_tests/no_column_header_definition.tsv')
+        ds = pd.read_csv(ds_path, delimiter="\t", header=None)
         hed_input = SpreadsheetInput(ds, has_column_names=False, tag_columns=[1, 2])
 
         events_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/tests/models/test_spreadsheet_input.py
+++ b/tests/models/test_spreadsheet_input.py
@@ -6,6 +6,7 @@ from hed.errors import HedFileError
 from hed.models import TabularInput, SpreadsheetInput, model_constants, Sidecar
 import shutil
 from hed import schema
+import pandas as pd
 
 
 # TODO: Add tests about correct handling of 'n/a'
@@ -197,6 +198,44 @@ class Test(unittest.TestCase):
         for column1, column2 in zip(hed_input, hed_input_long):
             self.assertEqual(column1, column2)
 
+    def test_convert_short_long_with_definitions_new_style(self):
+        # Verify behavior works as expected even if definitions are present
+        events_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   '../data/model_tests/no_column_header_definition.tsv')
+        hed_input = SpreadsheetInput(events_path, has_column_names=False, tag_columns=[1, 2],
+                                     hed_schema=self.hed_schema)
+        hed_input.convert_to_long()
+
+        events_path_long = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                        '../data/model_tests/no_column_header_definition_long.tsv')
+        hed_input_long = SpreadsheetInput(events_path_long, has_column_names=False, tag_columns=[1, 2])
+        for column1, column2 in zip(hed_input, hed_input_long):
+            self.assertEqual(column1, column2)
+
+    def test_definitions_identified(self):
+        events_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   '../data/model_tests/no_column_header_definition.tsv')
+        hed_input = SpreadsheetInput(events_path, has_column_names=False, tag_columns=[1, 2],
+                                     hed_schema=self.hed_schema)
+        def_entry = hed_input.def_dict['deftest1']
+        tag = def_entry.contents.tags()[0]
+        self.assertTrue(tag._schema_entry)
+        events_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   '../data/model_tests/no_column_header_definition.tsv')
+        hed_input = SpreadsheetInput(events_path, has_column_names=False, tag_columns=[1, 2])
+        def_entry = hed_input.def_dict['deftest1']
+        tag = def_entry.contents.tags()[0]
+        self.assertFalse(tag._schema_entry)
+
+    def test_loading_dataframe_directly(self):
+        ds = pd.read_csv("../data/model_tests/no_column_header_definition.tsv", delimiter="\t", header=None)
+        hed_input = SpreadsheetInput(ds, has_column_names=False, tag_columns=[1, 2])
+
+        events_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                   '../data/model_tests/no_column_header_definition.tsv')
+        hed_input2 = SpreadsheetInput(events_path, has_column_names=False, tag_columns=[1, 2])
+        for column1, column2 in zip(hed_input, hed_input2):
+            self.assertEqual(column1, column2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update baseinput/sidecar derived classes to take a hed schema in constructor. If present, identify tags in definitions, and also use as the default schema if one isn't passed later.
Also allow BaseInput to directly take a pandas dataframe.