### PR TITLE
Split code coverage upload out of main build job.  

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     strategy:
       matrix:
         platform: [ubuntu-latest]
@@ -17,15 +16,20 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade --upgrade-strategy eager pip
           pip install flake8
           pip install coverage
           pip install -r requirements.txt
@@ -42,10 +46,48 @@ jobs:
         run: |
           HED_GITHUB_TOKEN=${{ secrets.HED_GITHUB_TOKEN }} coverage run -m unittest
 
+      - name: Archive code coverage results
+        if: ${{matrix.python-version == '3.9'}}
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: .coverage
+
+  coverage:
+    name: Publish coverage
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev-requirements.txt') }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade --upgrade-strategy eager pip
+          pip install flake8
+          pip install coverage
+          pip install -r requirements.txt
+          pip install -r docs/requirements.txt
+
+      - name: Download a single artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: code-coverage-report
+
       - name: publish-coverages
-        uses: paambaati/codeclimate-action@v2.7.5
+        with:
+          coverageCommand: coverage xml
+          debug: true
+        uses: paambaati/codeclimate-action@v3.2.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-            coverageCommand: coverage xml
-            debug: true
+


### PR DESCRIPTION
Cache the python env for a minor speedup.