### PR TITLE
Update workflow to check for secrets before trying to publish coverages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,10 +53,27 @@ jobs:
           name: code-coverage-report
           path: .coverage
 
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      secrets-exist: ${{ steps.check-for-secrets.outputs.defined }}
+    steps:
+      - name: Check for Secret availability
+        id: check-for-secrets
+        # perform secret check & put boolean result as an output
+        shell: bash
+        run: |
+          if [ "${{ secrets.CC_TEST_REPORTER_ID }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
+
   coverage:
     name: Publish coverage
-    needs: build
+    needs: [build, check-secret]
     runs-on: ubuntu-latest
+    if: needs.check-secret.outputs.secrets-exist == 'true'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We can take another crack at improving the workflow later, but this should fix the issue of code climate failing on PR's.  It entirely skips that job now if there is no CC ID.