### PR TITLE
HED string indentation

### DIFF
--- a/hed/models/hed_group.py
+++ b/hed/models/hed_group.py
@@ -286,7 +286,7 @@ class HedGroup:
         """
         if self.is_group:
             return "(" + ",".join([str(child) for child in self.children]) + ")"
-        return ",".join([str(child) for child in self.children])
+        return ", ".join([str(child) for child in self.children])
 
     def get_as_short(self):
         """ Return this HedGroup as a short tag string.
@@ -531,3 +531,5 @@ class HedGroup:
         if include_groups == 0 or include_groups == 1:
             return [tag[include_groups] for tag in found_tags]
         return found_tags
+
+    

--- a/hed/models/hed_string.py
+++ b/hed/models/hed_string.py
@@ -383,3 +383,29 @@ class HedString(HedGroup):
         ref_tags = [tag for tag in self.get_all_tags() if tag.is_column_ref()]
         if ref_tags:
             self.remove(ref_tags)
+            
+    def indent(self):
+        self.sort()
+        hed_string = self.__str__()
+
+        level_open = []
+        level = 0
+        indented = ""
+        prev = ''
+        for c in hed_string:
+            if c == "(":
+                level_open.append(level)
+                indented += "\n" + "\t"*level + c
+                level += 1	
+            elif c == ")":
+                level = level_open.pop()
+                if prev == ")":
+                    indented += "\n" + "\t"*level + c
+                else:
+                    indented += c
+                
+            else:
+                indented += c
+            prev = c
+        
+        return indented


### PR DESCRIPTION
Reformat the HED string by indenting tag groups. The current implementation modify hed string internally by calling `sort()`. We might want to allow `sort()` to return a sorted hed string if we don't want internal modification by default when `indent()` is called