### PR TITLE
Turn on allowed character support in > 8.3

### DIFF
--- a/hed/errors/schema_error_messages.py
+++ b/hed/errors/schema_error_messages.py
@@ -94,9 +94,10 @@ def schema_error_SCHEMA_CONVERSION_FACTOR_NOT_POSITIVE(tag, conversion_factor):
 @hed_error(SchemaAttributeErrors.SCHEMA_ALLOWED_CHARACTERS_INVALID,
            actual_code=SchemaAttributeErrors.SCHEMA_ATTRIBUTE_VALUE_INVALID)
 def schema_error_SCHEMA_ALLOWED_CHARACTERS_INVALID(tag, invalid_character):
+    from hed.schema.hed_schema_constants import character_types
     return (f"Tag '{tag}' has an invalid allowedCharacter: '{invalid_character}'.  "
             f"Allowed characters are: a single character, "
-            f"or one of the following - letters, blank, digits, alphanumeric.")
+            f"or one of the following - {', '.join(character_types.keys())}.")
 
 
 @hed_error(SchemaAttributeErrors.SCHEMA_IN_LIBRARY_INVALID,

--- a/hed/schema/hed_schema_constants.py
+++ b/hed/schema/hed_schema_constants.py
@@ -87,3 +87,11 @@ valid_header_attributes = {
     NO_LOC_ATTRIB,
     UNMERGED_ATTRIBUTE
 }
+
+character_types = {
+    "letters": set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+    "blank": set(" "),
+    "digits": set("0123456789"),
+    "alphanumeric": set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"),
+    "nonascii": "nonascii"  # Special case for all other printable unicode characters
+}

--- a/hed/schema/schema_attribute_validators.py
+++ b/hed/schema/schema_attribute_validators.py
@@ -14,7 +14,7 @@ Returns:
 from hed.errors.error_types import SchemaWarnings, ValidationErrors, SchemaAttributeErrors
 from hed.errors.error_reporter import ErrorHandler
 from hed.schema.hed_cache import get_hed_versions
-from hed.schema.hed_schema_constants import HedKey
+from hed.schema.hed_schema_constants import HedKey, character_types
 
 
 def tag_is_placeholder_check(hed_schema, tag_entry, attribute_name):
@@ -141,6 +141,10 @@ def tag_is_deprecated_check(hed_schema, tag_entry, attribute_name):
     deprecated_version = tag_entry.attributes.get(attribute_name, "")
     library_name = tag_entry.has_attribute(HedKey.InLibrary, return_value=True)
     all_versions = get_hed_versions(library_name=library_name)
+    if not library_name:
+        library_name = ""
+    if library_name == hed_schema.library and hed_schema.version_number not in all_versions:
+        all_versions.append(hed_schema.version_number)
     if deprecated_version and deprecated_version not in all_versions:
         issues += ErrorHandler.format_error(SchemaAttributeErrors.SCHEMA_DEPRECATED_INVALID,
                                             tag_entry.name,
@@ -182,7 +186,7 @@ def allowed_characters_check(hed_schema, tag_entry, attribute_name):
 
     """
     issues = []
-    allowed_strings = {'letters', 'blank', 'digits', 'alphanumeric'}
+    allowed_strings = character_types
 
     char_string = tag_entry.attributes.get(attribute_name, "")
     characters = char_string.split(",")

--- a/hed/schema/schema_compliance.py
+++ b/hed/schema/schema_compliance.py
@@ -125,6 +125,7 @@ class SchemaValidator:
             for tag_name, desc in self.hed_schema.get_desc_iter():
                 issues_list += validate_schema_description(tag_name, desc)
 
+        # todo: Do we want to add this?
         # todo Activate this session once we have clearer rules on spaces in unit names
         # for unit in self.hed_schema.units:
         #     for i, char in enumerate(unit):

--- a/hed/tools/visualization/tag_word_cloud.py
+++ b/hed/tools/visualization/tag_word_cloud.py
@@ -3,9 +3,10 @@
 import numpy as np
 from PIL import Image
 from hed.tools.visualization.word_cloud_util import default_color_func, WordCloud, generate_contour_svg
+import matplotlib.font_manager as fm
 
 
-def create_wordcloud(word_dict, mask_path=None, background_color=None, width=400, height=300, **kwargs):
+def create_wordcloud(word_dict, mask_path=None, background_color=None, width=400, height=300, font_path=None, **kwargs):
     """ Takes a word dict and returns a generated word cloud object.
 
     Parameters:
@@ -14,6 +15,8 @@ def create_wordcloud(word_dict, mask_path=None, background_color=None, width=400
         background_color (str or None): If None, transparent background.
         width (int): width in pixels.
         height (int): height in pixels.
+        font_path (str): a filename or font name to use.  Assumed to be a full file path if it ends with .ttf or .otf.
+                         Font names will use a default if a close enough match isn't found.
         kwargs (kwargs): Any other parameters WordCloud accepts, overrides default values where relevant.
 
     Returns:
@@ -41,9 +44,11 @@ def create_wordcloud(word_dict, mask_path=None, background_color=None, width=400
     kwargs.setdefault('color_func', default_color_func)
     kwargs.setdefault('relative_scaling', 1)
     kwargs.setdefault('max_font_size', height / 20)
-    kwargs.setdefault('min_font_size', 8),
+    kwargs.setdefault('min_font_size', 8)
+    if font_path and not font_path.endswith(".ttf") and not font_path.endswith(".otf"):
+        font_path = fm.findfont(font_path)
 
-    wc = WordCloud(background_color=background_color, mask=mask_image,
+    wc = WordCloud(font_path=font_path, background_color=background_color, mask=mask_image,
                    width=width, height=height, mode="RGBA", **kwargs)
 
     wc.generate_from_frequencies(word_dict)

--- a/hed/validator/hed_validator.py
+++ b/hed/validator/hed_validator.py
@@ -31,7 +31,7 @@ class HedValidator:
         self._def_validator = DefValidator(def_dicts, hed_schema)
         self._definitions_allowed = definitions_allowed
 
-        self._unit_validator = UnitValueValidator()
+        self._unit_validator = UnitValueValidator(hed_schema)
         self._char_validator = CharValidator()
         self._string_validator = StringValidator()
         self._tag_validator = TagValidator()

--- a/hed/validator/tag_util/char_util.py
+++ b/hed/validator/tag_util/char_util.py
@@ -33,7 +33,7 @@ class CharValidator:
         if allow_placeholders:
             invalid_dict = self.INVALID_STRING_CHARS_PLACEHOLDERS
         for index, character in enumerate(hed_string):
-            if character in invalid_dict or ord(character) > 127:
+            if character in invalid_dict or not character.isprintable():
                 validation_issues += self._report_invalid_character_error(hed_string, index)
 
         return validation_issues

--- a/hed/validator/tag_util/char_util.py
+++ b/hed/validator/tag_util/char_util.py
@@ -14,6 +14,14 @@ class CharValidator:
     INVALID_STRING_CHARS = '[]{}~'
     INVALID_STRING_CHARS_PLACEHOLDERS = '[]~'
 
+    def __init__(self, modern_allowed_char_rules=False):
+        """Does basic character validation for hed strings/tags
+
+        Parameters:
+            modern_allowed_char_rules(bool): If True, use 8.3 style rules for unicode characters.
+        """
+        self._validate_characters = modern_allowed_char_rules
+
     def check_invalid_character_issues(self, hed_string, allow_placeholders):
         """ Report invalid characters.
 
@@ -33,8 +41,12 @@ class CharValidator:
         if allow_placeholders:
             invalid_dict = self.INVALID_STRING_CHARS_PLACEHOLDERS
         for index, character in enumerate(hed_string):
-            if character in invalid_dict or not character.isprintable():
-                validation_issues += self._report_invalid_character_error(hed_string, index)
+            if self._validate_characters:
+                if character in invalid_dict or not character.isprintable():
+                    validation_issues += self._report_invalid_character_error(hed_string, index)
+            else:
+                if character in invalid_dict or ord(character) > 127:
+                    validation_issues += self._report_invalid_character_error(hed_string, index)
 
         return validation_issues
 

--- a/hed/validator/tag_util/class_util.py
+++ b/hed/validator/tag_util/class_util.py
@@ -2,13 +2,12 @@
 import datetime
 import re
 import functools
-from semantic_version import Version
 
 
 from hed.errors.error_reporter import ErrorHandler
 from hed.errors.error_types import ValidationErrors
 from hed.schema.hed_schema_constants import HedKey, character_types
-from hed.schema import HedSchema
+
 
 class UnitValueValidator:
     """ Validates units. """
@@ -21,20 +20,14 @@ class UnitValueValidator:
 
     VALUE_CLASS_ALLOWED_CACHE = 20
 
-    def __init__(self, hed_schema, value_validators=None):
+    def __init__(self, modern_allowed_char_rules=False, value_validators=None):
         """ Validates the unit and value classes on a given tag.
 
         Parameters:
             value_validators(dict or None): Override or add value class validators
 
         """
-        self._validate_characters = False
-        # todo: Extend character validation for schema groups eventually
-        if isinstance(hed_schema, HedSchema):
-            validation_version = hed_schema.with_standard
-            if not validation_version:
-                validation_version = hed_schema.version_number
-            self._validate_characters = Version(validation_version) >= Version("8.3.0")
+        self._validate_characters = modern_allowed_char_rules
         self._value_validators = self._get_default_value_class_validators()
         if value_validators and isinstance(value_validators, dict):
             self._value_validators.update(value_validators)

--- a/tests/data/schema_tests/schema_utf8.mediawiki
+++ b/tests/data/schema_tests/schema_utf8.mediawiki
@@ -1,0 +1,168 @@
+HED version="8.3.0" unmerged="True"
+
+'''Prologue'''
+
+!# start schema
+
+'''Tag1'''
+* Café
+
+'''Ascii'''
+ * # {takesValue, valueClass=textClass}
+
+ '''NonAscii'''
+ * # {takesValue, valueClass=testUnicodeClass}
+
+!# end schema
+
+'''Unit classes''' <nowiki>[Unit classes and the units for the nodes.]</nowiki>
+* accelerationUnits <nowiki>{defaultUnits=m-per-s^2}</nowiki>
+** m-per-s^2 <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+* angleUnits <nowiki>{defaultUnits=radian}</nowiki>
+** radian <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** rad <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+** degree <nowiki>{conversionFactor=0.0174533}</nowiki>
+* areaUnits <nowiki>{defaultUnits=m^2}</nowiki>
+** m^2 <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+* currencyUnits <nowiki>{defaultUnits=$}[Units indicating the worth of something.]</nowiki>
+** dollar <nowiki>{conversionFactor=1.0}</nowiki>
+** $ <nowiki>{unitPrefix, unitSymbol, conversionFactor=1.0}</nowiki>
+** euro
+** point
+* electricPotentialUnits <nowiki>{defaultUnits=uv}</nowiki>
+** v <nowiki>{SIUnit, unitSymbol, conversionFactor=0.000001}</nowiki>
+** Volt <nowiki>{SIUnit, conversionFactor=0.000001}</nowiki>
+* frequencyUnits <nowiki>{defaultUnits=Hz}</nowiki>
+** hertz  <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** Hz <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+* intensityUnits <nowiki>{defaultUnits=dB}</nowiki>
+** dB <nowiki>{unitSymbol, conversionFactor=1.0}[Intensity expressed as ratio to a threshold. May be used for sound intensity.]</nowiki>
+** candela <nowiki>{SIUnit}[Units used to express light intensity.]</nowiki>
+** cd <nowiki>{SIUnit, unitSymbol}[Units used to express light intensity.]</nowiki>
+* jerkUnits <nowiki>{defaultUnits=m-per-s^3}</nowiki>
+** m-per-s^3 <nowiki>{unitSymbol, conversionFactor=1.0}</nowiki>
+* magneticFieldUnits <nowiki>{defaultUnits=fT}[Units used to magnetic field intensity.]</nowiki>
+** tesla <nowiki>{SIUnit, conversionFactor=10^-15}</nowiki>
+** T <nowiki>{SIUnit, unitSymbol, conversionFactor=10^-15}</nowiki>
+* memorySizeUnits <nowiki>{defaultUnits=B}</nowiki>
+** byte <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** B <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+* physicalLengthUnits <nowiki>{defaultUnits=m}</nowiki>
+** foot <nowiki>{conversionFactor=0.3048}</nowiki>
+** inch <nowiki>{conversionFactor=0.0254}</nowiki>
+** meter <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** metre <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** m <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+** mile <nowiki>{conversionFactor=1609.34}</nowiki>
+* speedUnits <nowiki>{defaultUnits=m-per-s}</nowiki>
+** m-per-s <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+** mph <nowiki>{unitSymbol, conversionFactor=0.44704}</nowiki>
+** kph <nowiki>{unitSymbol, conversionFactor=0.277778}</nowiki>
+* temperatureUnits <nowiki>{defaultUnits=degree Celsius}</nowiki>
+** degree Celsius <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** oC <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+* timeUnits <nowiki>{defaultUnits=s}</nowiki>
+** second <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** s <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+** day <nowiki>{conversionFactor=86400}</nowiki>
+** minute <nowiki>{conversionFactor=60}</nowiki>
+** hour <nowiki>{conversionFactor=3600}[Should be in 24-hour format.]</nowiki>
+* volumeUnits <nowiki>{defaultUnits=m^3}</nowiki>
+** m^3 <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+* weightUnits <nowiki>{defaultUnits=g}</nowiki>
+** g <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+** gram <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+** pound <nowiki>{conversionFactor=453.592}</nowiki>
+** lb <nowiki>{conversionFactor=453.592}</nowiki>
+
+
+'''Unit modifiers''' <nowiki>[Unit multiples and submultiples.]</nowiki>
+* deca <nowiki>{SIUnitModifier, conversionFactor=10.0} [SI unit multiple representing 10^1.]</nowiki>
+* da <nowiki>{SIUnitSymbolModifier, conversionFactor=10.0} [SI unit multiple representing 10^1.]</nowiki>
+* hecto <nowiki>{SIUnitModifier, conversionFactor=100.0} [SI unit multiple representing 10^2.]</nowiki>
+* h <nowiki>{SIUnitSymbolModifier, conversionFactor=100.0} [SI unit multiple representing 10^2.]</nowiki>
+* kilo <nowiki>{SIUnitModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3.]</nowiki>
+* k <nowiki>{SIUnitSymbolModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3.]</nowiki>
+* mega <nowiki>{SIUnitModifier, conversionFactor=10^6} [SI unit multiple representing 10^6.]</nowiki>
+* M <nowiki>{SIUnitSymbolModifier, conversionFactor=10^6} [SI unit multiple representing 10^6.]</nowiki>
+* giga <nowiki>{SIUnitModifier, conversionFactor=10^9} [SI unit multiple representing 10^9.]</nowiki>
+* G <nowiki>{SIUnitSymbolModifier, conversionFactor=10^9} [SI unit multiple representing 10^9.]</nowiki>
+* tera <nowiki>{SIUnitModifier, conversionFactor=10^12} [SI unit multiple representing 10^12.]</nowiki>
+* T <nowiki>{SIUnitSymbolModifier, conversionFactor=10^12} [SI unit multiple representing 10^12.]</nowiki>
+* peta <nowiki>{SIUnitModifier, conversionFactor=10^15} [SI unit multiple representing 10^15.]</nowiki>
+* P <nowiki>{SIUnitSymbolModifier, conversionFactor=10^15} [SI unit multiple representing 10^15.]</nowiki>
+* exa <nowiki>{SIUnitModifier, conversionFactor=10^18} [SI unit multiple representing 10^18.]</nowiki>
+* E <nowiki>{SIUnitSymbolModifier, conversionFactor=10^18} [SI unit multiple representing 10^18.]</nowiki>
+* zetta <nowiki>{SIUnitModifier, conversionFactor=10^21} [SI unit multiple representing 10^21.]</nowiki>
+* Z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^21} [SI unit multiple representing 10^21.]</nowiki>
+* yotta <nowiki>{SIUnitModifier, conversionFactor=10^24} [SI unit multiple representing 10^24.]</nowiki>
+* Y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^24} [SI unit multiple representing 10^24.]</nowiki>
+* deci <nowiki>{SIUnitModifier, conversionFactor=0.1}[SI unit submultiple representing 10^-1.]</nowiki>
+* d <nowiki>{SIUnitSymbolModifier, conversionFactor=0.1} [SI unit submultiple representing 10^-1.]</nowiki>
+* centi <nowiki>{SIUnitModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2.]</nowiki>
+* c <nowiki>{SIUnitSymbolModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2.]</nowiki>
+* milli <nowiki>{SIUnitModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3.]</nowiki>
+* m <nowiki>{SIUnitSymbolModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3.]</nowiki>
+* micro <nowiki>{SIUnitModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6.]</nowiki>
+* u <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6.]</nowiki>
+* nano <nowiki>{SIUnitModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9.]</nowiki>
+* n <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9.]</nowiki>
+* pico <nowiki>{SIUnitModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12.]</nowiki>
+* p <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12.]</nowiki>
+* femto <nowiki>{SIUnitModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15.]</nowiki>
+* f <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15.]</nowiki>
+* atto <nowiki>{SIUnitModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18.]</nowiki>
+* a <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18.]</nowiki>
+* zepto <nowiki>{SIUnitModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21.]</nowiki>
+* z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21.]</nowiki>
+* yocto <nowiki>{SIUnitModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24.]</nowiki>
+* y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24.]</nowiki>
+
+
+'''Value classes''' <nowiki>[Specification of the rules for the values provided by users.]</nowiki>
+* dateTimeClass <nowiki>{allowedCharacter=digits,allowedCharacter=T,allowedCharacter=-,allowedCharacter=:}[Date-times should conform to ISO8601 date-time format YYYY-MM-DDThh:mm:ss. Any variation on the full form is allowed.]</nowiki>
+* nameClass <nowiki>{allowedCharacter=letters,allowedCharacter=digits,allowedCharacter=_,allowedCharacter=-}[Value class designating values that have the characteristics of node names. The allowed characters are alphanumeric, hyphen, and underbar.]</nowiki>
+* numericClass <nowiki>{allowedCharacter=digits,allowedCharacter=E,allowedCharacter=e,allowedCharacter=+,allowedCharacter=-,allowedCharacter=.}[Value must be a valid numerical value.]</nowiki>
+* posixPath <nowiki>{allowedCharacter=digits,allowedCharacter=letters,allowedCharacter=/,allowedCharacter=:}[Posix path specification.]</nowiki>
+* textClass <nowiki>{allowedCharacter=letters, allowedCharacter=digits, allowedCharacter=blank, allowedCharacter=+, allowedCharacter=-, allowedCharacter=:, allowedCharacter=;, allowedCharacter=., allowedCharacter=/, allowedCharacter=(, allowedCharacter=), allowedCharacter=?, allowedCharacter=*, allowedCharacter=%, allowedCharacter=$, allowedCharacter=@}[Value class designating values that have the characteristics of text such as in descriptions.]</nowiki>
+* testUnicodeClass <nowiki>{allowedCharacter=letters, allowedCharacter=nonascii, allowedCharacter=digits, allowedCharacter=blank, allowedCharacter=+, allowedCharacter=-, allowedCharacter=:, allowedCharacter=;, allowedCharacter=., allowedCharacter=/, allowedCharacter=(, allowedCharacter=), allowedCharacter=?, allowedCharacter=*, allowedCharacter=%, allowedCharacter=$, allowedCharacter=@}[Test class to see if unicode is allowed]</nowiki>
+
+'''Schema attributes''' <nowiki>[Allowed attribute modifiers of other sections of the schema.]</nowiki>
+* allowedCharacter <nowiki>{valueClassProperty}[A schema attribute of value classes specifying a special character that is allowed in expressing the value of a placeholder. Normally the allowed characters are listed individually. However, the word letters designates the upper and lower case alphabetic characters and the word digits designates the digits 0-9. The word blank designates the blank character.]</nowiki>
+* conversionFactor <nowiki>{unitProperty, unitModifierProperty}[The multiplicative factor to multiply these units to convert to default units.]</nowiki>
+* deprecatedFrom <nowiki>{elementProperty}[Indicates that this element is deprecated. The value of the attribute is the latest schema version in which the element appeared in undeprecated form.]</nowiki>
+* defaultUnits <nowiki>{unitClassProperty}[A schema attribute of unit classes specifying the default units to use if the placeholder has a unit class but the substituted value has no units.]</nowiki>
+* extensionAllowed <nowiki>{boolProperty, nodeProperty, isInheritedProperty}[A schema attribute indicating that users can add unlimited levels of child nodes under this tag. This tag is propagated to child nodes with the exception of the hashtag placeholders.]</nowiki>
+* inLibrary <nowiki>{elementProperty} [Indicates this schema element came from the named library schema, not the standard schema. This attribute is added by tools when a library schema is merged into its partnered standard schema.]</nowiki>
+* recommended  <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating that the event-level HED string should include this tag.]</nowiki>
+* relatedTag <nowiki>{nodeProperty, isInheritedProperty}[A schema attribute suggesting HED tags that are closely related to this tag. This attribute is used by tagging tools.]</nowiki>
+* requireChild  <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating that one of the node elements descendants must be included when using this tag.]</nowiki>
+* required <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating that every event-level HED string should include this tag.]</nowiki>
+* reserved <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating that this tag has special meaning and requires special handling by tools.]</nowiki>
+* rooted <nowiki>{nodeProperty}[Indicates a top-level library schema node is identical to a node of the same name in the partnered standard schema. This attribute can only appear in nodes that have the inLibrary schema attribute.]</nowiki>
+* SIUnit  <nowiki>{boolProperty, unitProperty}[A schema attribute indicating that this unit element is an SI unit and can be modified by multiple and submultiple names. Note that some units such as byte are designated as SI units although they are not part of the standard.]</nowiki>
+* SIUnitModifier <nowiki>{boolProperty, unitModifierProperty}[A schema attribute indicating that this SI unit modifier represents a multiple or submultiple of a base unit rather than a unit symbol.]</nowiki>
+* SIUnitSymbolModifier <nowiki>{boolProperty, unitModifierProperty}[A schema attribute indicating that this SI unit modifier represents a multiple or submultiple of a unit symbol rather than a base symbol.]</nowiki>
+* suggestedTag <nowiki>{nodeProperty, isInheritedProperty}[A schema attribute that indicates another tag  that is often associated with this tag. This attribute is used by tagging tools to provide tagging suggestions.]</nowiki>
+* tagGroup <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating the tag can only appear inside a tag group.] </nowiki>
+* takesValue <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating the tag is a hashtag placeholder that is expected to be replaced with a user-defined value.] </nowiki>
+* topLevelTagGroup <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating that this tag (or its descendants) can only appear in a top-level tag group. A tag group can have at most one tag with this attribute.] </nowiki>
+* unique <nowiki>{boolProperty, nodeProperty}[A schema attribute indicating that only one of this tag or its descendants can be used  in the event-level HED string.]</nowiki>
+* unitClass <nowiki>{nodeProperty}[A schema attribute specifying which unit class this value tag belongs to.]</nowiki>
+* unitPrefix <nowiki>{boolProperty, unitProperty}[A schema attribute applied specifically to unit elements to designate that the unit indicator is a prefix (e.g., dollar sign in the currency units).]</nowiki>
+* unitSymbol <nowiki>{boolProperty, unitProperty}[A schema attribute indicating this tag is an abbreviation or symbol representing a type of unit. Unit symbols represent both the singular and the plural and thus cannot be pluralized.]</nowiki>
+* valueClass <nowiki>{nodeProperty}[A schema attribute specifying which value class this value tag belongs to.]</nowiki>
+
+'''Properties''' <nowiki>[Properties of the schema attributes themselves. These are used for schema handling and verification.]</nowiki>
+* boolProperty <nowiki>[Indicates that the schema attribute represents something that is either true or false and does not have a value. Attributes without this value are assumed to have string values.]</nowiki>
+* elementProperty <nowiki>[Indicates this schema attribute can apply to any type of element(tag term, unit class, etc).]</nowiki>
+* isInheritedProperty <nowiki>[Indicates that this attribute is inherited by child nodes. This property only applies to schema attributes for nodes.]</nowiki>
+* nodeProperty <nowiki>[Indicates this schema attribute applies to node (tag-term) elements. This was added to allow for an attribute to apply to multiple elements.]</nowiki>
+* unitClassProperty <nowiki>[Indicates that the schema attribute is meant to be applied to unit classes.]</nowiki>
+* unitModifierProperty <nowiki>[Indicates that the schema attribute is meant to be applied to unit modifier classes.]</nowiki>
+* unitProperty <nowiki>[Indicates that the schema attribute is meant to be applied to units within a unit class.]</nowiki>
+* valueClassProperty <nowiki>[Indicates that the schema attribute is meant to be applied to value classes.]</nowiki>
+
+'''Epilogue'''
+
+!# end hed

--- a/tests/schema/test_schema_attribute_validators.py
+++ b/tests/schema/test_schema_attribute_validators.py
@@ -87,7 +87,7 @@ class Test(unittest.TestCase):
         self.assertFalse(schema_attribute_validators.tag_is_deprecated_check(self.hed_schema, tag_entry, attribute_name))
         
     def test_conversionFactor(self):
-        tag_entry = self.hed_schema.unit_classes["accelerationUnits"].units['m-per-s^2']
+        tag_entry = self.hed_schema.unit_classes["accelerationUnits"].units["m-per-s^2"]
         attribute_name = "conversionFactor"
         self.assertFalse(schema_attribute_validators.conversion_factor(self.hed_schema, tag_entry, attribute_name))
 
@@ -102,7 +102,7 @@ class Test(unittest.TestCase):
         self.assertTrue(schema_attribute_validators.conversion_factor(self.hed_schema, tag_entry, attribute_name))
 
     def test_conversionFactor_modifier(self):
-        tag_entry = self.hed_schema.unit_classes["magneticFieldUnits"].units['tesla']
+        tag_entry = self.hed_schema.unit_classes["magneticFieldUnits"].units["tesla"]
         attribute_name = "conversionFactor"
         self.assertFalse(schema_attribute_validators.conversion_factor(self.hed_schema, tag_entry, attribute_name))
 
@@ -119,7 +119,7 @@ class Test(unittest.TestCase):
     def test_allowed_characters_check(self):
         tag_entry = self.hed_schema.value_classes["dateTimeClass"]
         attribute_name = "allowedCharacter"
-        valid_attributes = {'letters', 'blank', 'digits', 'alphanumeric', ":", "$", "a"}
+        valid_attributes = {"letters", "blank", "digits", "alphanumeric", ":", "$", "a"}
         self.assertFalse(schema_attribute_validators.allowed_characters_check(self.hed_schema, tag_entry, attribute_name))
 
         tag_entry = copy.deepcopy(tag_entry)
@@ -127,7 +127,7 @@ class Test(unittest.TestCase):
             tag_entry.attributes[attribute_name] = attribute
             self.assertFalse(schema_attribute_validators.allowed_characters_check(self.hed_schema, tag_entry, attribute_name))
 
-        invalid_attributes = {'lettersdd', 'notaword', ":a"}
+        invalid_attributes = {"lettersdd", "notaword", ":a"}
         for attribute in invalid_attributes:
             tag_entry.attributes[attribute_name] = attribute
             self.assertTrue(schema_attribute_validators.allowed_characters_check(self.hed_schema, tag_entry, attribute_name))

--- a/tests/tools/visualization/test_tag_word_cloud.py
+++ b/tests/tools/visualization/test_tag_word_cloud.py
@@ -2,6 +2,7 @@ import unittest
 import wordcloud
 from hed.tools.visualization import tag_word_cloud
 from hed.tools.visualization.tag_word_cloud import load_and_resize_mask
+import matplotlib.font_manager as fm
 
 import numpy as np
 from PIL import Image, ImageDraw
@@ -23,6 +24,32 @@ class TestWordCloudFunctions(unittest.TestCase):
         self.assertIsInstance(wc, wordcloud.WordCloud)
         self.assertEqual(wc.width, width)
         self.assertEqual(wc.height, height)
+
+    def test_create_wordcloud_font(self):
+        word_dict = {'tag1': 5, 'tag2': 3, 'tag3': 7}
+        width = 400
+        height = 200
+        wc = tag_word_cloud.create_wordcloud(word_dict, width=width, height=height, font_path="Sarai")
+
+        self.assertIsInstance(wc, wordcloud.WordCloud)
+        self.assertEqual(wc.width, width)
+        self.assertEqual(wc.height, height)
+        self.assertIn("Sarai", wc.font_path)
+
+    def test_create_wordcloud_font_direct(self):
+        word_dict = {'tag1': 5, 'tag2': 3, 'tag3': 7}
+        width = 400
+        height = 200
+
+        fonts = fm.findSystemFonts()
+        first_font = fonts[0]
+
+        wc = tag_word_cloud.create_wordcloud(word_dict, width=width, height=height, font_path=first_font)
+
+        self.assertIsInstance(wc, wordcloud.WordCloud)
+        self.assertEqual(wc.width, width)
+        self.assertEqual(wc.height, height)
+        self.assertIn(first_font, wc.font_path)
 
     def test_create_wordcloud_default_params(self):
         word_dict = {'tag1': 5, 'tag2': 3, 'tag3': 7}

--- a/tests/tools/visualization/test_tag_word_cloud.py
+++ b/tests/tools/visualization/test_tag_word_cloud.py
@@ -29,12 +29,12 @@ class TestWordCloudFunctions(unittest.TestCase):
         word_dict = {'tag1': 5, 'tag2': 3, 'tag3': 7}
         width = 400
         height = 200
-        wc = tag_word_cloud.create_wordcloud(word_dict, width=width, height=height, font_path="Sarai")
+        wc = tag_word_cloud.create_wordcloud(word_dict, width=width, height=height, font_path="Serif")
 
         self.assertIsInstance(wc, wordcloud.WordCloud)
         self.assertEqual(wc.width, width)
         self.assertEqual(wc.height, height)
-        self.assertIn("Sarai", wc.font_path)
+        self.assertIn("Serif", wc.font_path)
 
     def test_create_wordcloud_font_direct(self):
         word_dict = {'tag1': 5, 'tag2': 3, 'tag3': 7}

--- a/tests/validator/test_tag_validator.py
+++ b/tests/validator/test_tag_validator.py
@@ -949,5 +949,33 @@ class TestHedSpecialUnits(TestHed):
         self.validator_semantic(test_strings, expected_results, expected_issues, True)
 
 
+class TestHedAllowedCharacters(TestHed):
+    compute_forms = True
+    schema_file = '../data/schema_tests/schema_utf8.mediawiki'
+
+    @staticmethod
+    def string_obj_func(validator):
+        return partial(validator._validate_individual_tags_in_hed_string)
+
+    def test_special_units(self):
+        test_strings = {
+            'ascii': 'Ascii/bad-date',
+            'badascii': 'Ascii/bad-daté',
+            'nonascii': 'Nonascii/Café',
+        }
+        expected_results = {
+            'ascii': True,
+            'badascii': False,
+            'nonascii': True
+        }
+
+        expected_issues = {
+            'ascii': [],
+            'badascii': self.format_error(ValidationErrors.INVALID_TAG_CHARACTER, tag=0,
+                                          index_in_tag=13, index_in_tag_end=14),
+            'nonascii': []
+        }
+        self.validator_semantic(test_strings, expected_results, expected_issues, True)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Partial UTF8 support(allowedcharacter = nonascii)
Wordcloud now takes font_path, which can be a font name or full path.