### PR TITLE
Allow unordered df schema loading

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,0 @@
-[codespell]
-skip = .git,*.pdf,*.svg,deprecated,*.xml,*.mediawiki,*.omn,*.toml
-ignore-words-list = covert,hed,assertIn,parms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,5 +77,5 @@ namespaces = false
 hed = ["schema/schema_data/*.xml", "resources/*.png"]
 
 [tool.codespell]
-skip = '*.git,*.pdf,*.xml,*.mediawiki,*.svg,versioneer.py,venv*,*.tsv,*.yaml,*.yml,*.json,*.rdf,*.jsonld,spec_tests'
+skip = '*.git,*.pdf,*.svg,versioneer.py,venv*,*.tsv,*.yaml,*.yml,*.json,*.rdf,*.jsonld,spec_tests,,*.xml,*.mediawiki,*.omn,*.toml'
 ignore-words-list = 'te,parms,assertIn'


### PR DESCRIPTION
This makes it so tsv schemas can load with significantly less ordering.  Still requires parent tags defined before child tags, however.