### PR TITLE
Do not specify tagprefix since there is none in tags for hed-python

### DIFF
--- a/hed/_version.py
+++ b/hed/_version.py
@@ -51,7 +51,7 @@ def get_config() -> VersioneerConfig:
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = "hedtools-"
+    cfg.tag_prefix = ""
     cfg.parentdir_prefix = "hedtools-"
     cfg.versionfile_source = "hed/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
Without it "version" does not include version at all! E.g. could be

    ❯ python -c 'from hed._version import get_versions; print(get_versions())'
    {'version': '0+untagged.2400.g10fe30e', ...

after this fix

    ❯ python -c 'from hed._version import get_versions; print(get_versions())'
    {'version': '0.5.0+145.g10fe30e1.dirty', ...