### PR TITLE
Fixed validation for DefinitionDict

### DIFF
--- a/tests/data/sidecar_tests/both_types_events_with_defs.json
+++ b/tests/data/sidecar_tests/both_types_events_with_defs.json
@@ -20,12 +20,12 @@
    "stim_file": {
        "LongName": "Stimulus file name",
        "Description": "Relative path of the stimulus image file",
-       "HED": "Age/#, (Definition/JsonFileDef2/#, (Age/#,Item/JsonDef2)), (Definition/JsonFileDef3/#, (Age/#))"
+       "HED": "(Definition/JsonFileDef2/#, (Age/#,Item/JsonDef2)), (Definition/JsonFileDef3/#, (Age/#))"
    },
      "takes_value_def": {
        "LongName": "Def with a takes value tag",
        "Description": "Relative path of the stimulus image file",
-       "HED": "Age/#, (Definition/TakesValueDef/#, (Age/#))"
+       "HED": "(Definition/TakesValueDef/#, (Age/#))"
    },
   "unit_class_def": {
        "LongName": "Def with a value class",

--- a/tests/data/validator_tests/bids_events.json
+++ b/tests/data/validator_tests/bids_events.json
@@ -81,9 +81,16 @@
     },
     "defs": {
         "HED": {
-            "1": "Description/BCI acts randomly, (Definition/Random-selection, (Condition-variable, (Random, Predict))), Def/Random-selection",
-            "2": "Description/BCI was trained on data from stage 1., (Definition/Trained-on-random, (Condition-variable)), Def/Trained-on-random",
-            "3": "Description/BCI was trained on data from stages 1 and 2., (Definition/Trained-on-all, (Condition-variable)), Def/Trained-on-all"
+            "1": "Description/BCI acts randomly, Def/Random-selection",
+            "2": "Description/BCI was trained on data from stage 1., Def/Trained-on-random",
+            "3": "Description/BCI was trained on data from stages 1 and 2.,  Def/Trained-on-all"
+        }
+    },
+    "defs_actual": {
+      "HED":{
+            "1": "(Definition/Random-selection, (Condition-variable, (Random, Predict)))",
+            "2": "(Definition/Trained-on-random, (Condition-variable))",
+            "3": "(Definition/Trained-on-all, (Condition-variable))"
         }
     }
 }

--- a/tests/data/validator_tests/bids_events_bad_defs2.json
+++ b/tests/data/validator_tests/bids_events_bad_defs2.json
@@ -41,9 +41,9 @@
             "3": "Stage 3. BCI was trained on data from stages 1 and 2."
         },
 		"HED": {
-            "1": "Description/BCI acts randomly, (Definition/Random-selection, (Experimental-condition, (Random, Predict))), Def/Random-selection/InvalidPlaceholder",
-            "2": "Description/BCI was trained on data from stage 1., (Definition/Trained-on-random, (Experimental-condition)), Def/Trained-on-random",
-            "3": "Description/BCI was trained on data from stages 1 and 2."
+            "1": "(Definition/Random-selection, (Condition-variable/random-select, (Random, Predict)))",
+            "2": "(Definition/Trained-on-random, (Condition-variable/trained))",
+            "3": "(Definition/NextOne)"
 		}
     },
 	"trial": {

--- a/tests/models/test_definition_dict.py
+++ b/tests/models/test_definition_dict.py
@@ -1,6 +1,6 @@
 import unittest
 from hed.models.definition_dict import DefinitionDict
-from hed.errors import ErrorHandler, DefinitionErrors
+from hed.errors import ErrorHandler, DefinitionErrors, ValidationErrors, ErrorSeverity
 from hed.models.hed_string import HedString
 from hed import HedTag
 from hed import load_schema_version
@@ -15,17 +15,18 @@ class TestDefBase(TestHedBase):
     def check_def_base(self, test_strings, expected_issues):
         for test_key in test_strings:
             def_dict = DefinitionDict()
+            def_dict.add_definitions("(Definition/OkayDef, (White))", self.hed_schema)
             hed_string_obj = HedString(test_strings[test_key], self.hed_schema)
             test_issues = def_dict.check_for_definitions(hed_string_obj)
+            issues = [issue for issue in test_issues if issue['severity'] < ErrorSeverity.WARNING]
             expected_params = expected_issues[test_key]
             expected_issue = self.format_errors_fully(ErrorHandler(), hed_string=hed_string_obj,
                                                       params=expected_params)
-            self.assertCountEqual(test_issues, expected_issue, HedString(test_strings[test_key], self.hed_schema))
-
+            self.assertCountEqual(issues, expected_issue, HedString(test_strings[test_key], self.hed_schema))
 
 class TestDefinitionDict(TestDefBase):
-    def_contents_string = "(Item/TestDef1,Item/TestDef2)"
-    def_contents_string2 = "(Item/TestDef3,Item/TestDef4)"
+    def_contents_string = "(Item,Red)"
+    def_contents_string2 = "(Property, Blue)"
     basic_definition_string = f"(Definition/TestDef,{def_contents_string})"
     label_def_string = "def/TestDef"
     expanded_def_string = f"(Def-expand/TestDef,{def_contents_string})"
@@ -51,7 +52,7 @@ class TestDefinitionDict(TestDefBase):
         new_def_count = len(def_dict.defs)
         self.assertGreater(new_def_count, original_def_count)
 
-    placeholder_invalid_def_contents = "(Age/#,Item/TestDef2/#)"
+    placeholder_invalid_def_contents = "(Age/#,Item-count/#)"
     placeholder_invalid_def_string = f"(Definition/TestDefPlaceholder/#,{placeholder_invalid_def_contents})"
 
     def test_definitions(self):
@@ -62,17 +63,17 @@ class TestDefinitionDict(TestDefBase):
             'twoDefTags': f"(Definition/InvalidDef1,Definition/InvalidDef2,{self.def_contents_string})",
             'twoGroupTags': f"(Definition/InvalidDef1,{self.def_contents_string},{self.def_contents_string2})",
             'extraValidTags': "(Definition/InvalidDefA, Red, Blue)",
-            'extraOtherTags': "(Definition/InvalidDef1, InvalidContents)",
+            'extraOtherTags': "(Definition/InvalidDef1, Black)",
             'duplicateDef': (f"(Definition/Def1, {self.def_contents_string}), "
-                             f"(Definition/Def1, {self.def_contents_string})"),
+                             f"(Definition/Def1, (Green))"),
             'duplicateDef2': (f"(Definition/Def1, {self.def_contents_string}), "
                               f"(Definition/Def1/#, {self.placeholder_def_contents})"),
             'defTooManyPlaceholders': self.placeholder_invalid_def_string,
             'invalidPlaceholder': f"(Definition/InvalidDef1/InvalidPlaceholder, {self.def_contents_string})",
             'invalidPlaceholderExtension':
                 f"(Definition/InvalidDef1/this-part-is-not-allowed/#, {self.def_contents_string})",
-            'defInGroup': "(Definition/ValidDefName, (Def/ImproperlyPlacedDef))",
-            'defExpandInGroup': "(Definition/ValidDefName, (Def-expand/ImproperlyPlacedDef, (ImproperContents)))",
+            'defInGroup': "(Definition/ValidDefName, (Def/OkayDef))",
+            'defExpandInGroup': "(Definition/ValidDefName, (Def-expand/OkayDef, (White)))",
             'doublePoundSignPlaceholder': f"(Definition/InvalidDef/##, {self.placeholder_def_contents})",
             'doublePoundSignDiffPlaceholder': "(Definition/InvalidDef/#, (Age/##,Item/TestDef2))",
             'placeholdersWrongSpot': "(Definition/InvalidDef/#, (Age/#,Item/TestDef2))",
@@ -83,30 +84,31 @@ class TestDefinitionDict(TestDefBase):
             'placeholderWrongSpot': self.format_error(DefinitionErrors.NO_DEFINITION_CONTENTS, "InvalidDef1#") +
             self.format_error(DefinitionErrors.INVALID_DEFINITION_EXTENSION,
                               tag=0, def_name="InvalidDef1#"),
-            'twoDefTags': self.format_error(DefinitionErrors.WRONG_NUMBER_TAGS, "InvalidDef1",
-                                            ["Definition/InvalidDef2"]),
-            'twoGroupTags': self.format_error(DefinitionErrors.WRONG_NUMBER_GROUPS, "InvalidDef1",
-                                              [self.def_contents_string, self.def_contents_string2]),
-            'extraValidTags': self.format_error(DefinitionErrors.WRONG_NUMBER_TAGS, "InvalidDefA",
-                                                ["Red", "Blue"]),
-            'extraOtherTags': self.format_error(DefinitionErrors.WRONG_NUMBER_TAGS, "InvalidDef1",
-                                                ["InvalidContents"]),
+            'twoDefTags': self.format_error(ValidationErrors.HED_RESERVED_TAG_REPEATED, "Definition/InvalidDef2",
+                                            "(Definition/InvalidDef1,Definition/InvalidDef2,(Item,Red))"),
+            'twoGroupTags': self.format_error(ValidationErrors.HED_RESERVED_TAG_GROUP_ERROR,
+                                              "(Definition/InvalidDef1,(Item,Red),(Property,Blue))", 2,
+                                              ["Definition/InvalidDef1"]),
+            'extraValidTags': self.format_error(ValidationErrors.HED_TAGS_NOT_ALLOWED, "Red",
+                                                "(Definition/InvalidDefA,Red,Blue)"),
+            'extraOtherTags': self.format_error(ValidationErrors.HED_TAGS_NOT_ALLOWED, "Black",
+                                                "(Definition/InvalidDef1,Black)"),
             'duplicateDef': self.format_error(DefinitionErrors.DUPLICATE_DEFINITION, "Def1"),
             'duplicateDef2': self.format_error(DefinitionErrors.DUPLICATE_DEFINITION, "Def1"),
 
             'defTooManyPlaceholders': self.format_error(DefinitionErrors.WRONG_NUMBER_PLACEHOLDER_TAGS,
                                                         "TestDefPlaceholder", expected_count=1,
-                                                        tag_list=["Age/#", "Item/TestDef2/#"]),
-            'invalidPlaceholderExtension': self.format_error(DefinitionErrors.INVALID_DEFINITION_EXTENSION,
-                                                             tag=0, def_name="InvalidDef1/this-part-is-not-allowed"),
-            'invalidPlaceholder': self.format_error(DefinitionErrors.INVALID_DEFINITION_EXTENSION,
-                                                    tag=0, def_name="InvalidDef1/InvalidPlaceholder"),
+                                                        tag_list=["Age/#", "Item-count/#"]),
+            'invalidPlaceholderExtension': self.format_error(ValidationErrors.INVALID_VALUE_CLASS_CHARACTER,
+                 "Definition/InvalidDef1/this-part-is-not-allowed/#", "/", value_class="nameClass"),
+            'invalidPlaceholder': self.format_error(ValidationErrors.INVALID_VALUE_CLASS_CHARACTER,
+                 "Definition/InvalidDef1/InvalidPlaceholder", "/", value_class="nameClass"),
             'defInGroup': self.format_error(DefinitionErrors.DEF_TAG_IN_DEFINITION,
-                                            tag=HedTag("Def/ImproperlyPlacedDef", self.hed_schema),
+                                            tag=HedTag("Def/OkayDef", self.hed_schema),
                                             def_name="ValidDefName"),
-            'defExpandInGroup': self.format_error(DefinitionErrors.DEF_TAG_IN_DEFINITION,
-                                                  tag=HedTag("Def-expand/ImproperlyPlacedDef", self.hed_schema),
-                                                  def_name="ValidDefName"),
+            'defExpandInGroup': self.format_error(ValidationErrors.HED_TAGS_NOT_ALLOWED,
+                                                  tag=HedTag("Definition/ValidDefName", self.hed_schema),
+                                                  group="(Definition/ValidDefName,(Def-expand/OkayDef,(White)))"),
             'doublePoundSignPlaceholder': self.format_error(DefinitionErrors.INVALID_DEFINITION_EXTENSION,
                                                             tag=0, def_name="InvalidDef/##"),
             'doublePoundSignDiffPlaceholder': self.format_error(DefinitionErrors.WRONG_NUMBER_PLACEHOLDER_TAGS,
@@ -152,14 +154,16 @@ class TestDefinitionDict(TestDefBase):
         def_dict = DefinitionDict()
         def_dict.add_definitions("(Definition/testdefplaceholder,(Acceleration/#,Item/TestDef2,Red))",
                                   self.hed_schema)
-        self.assertEqual(len(def_dict.issues), 1)
+        self.assertEqual(len(def_dict.issues), 2)
+        errors = [issue for issue in def_dict.issues if issue['severity'] < ErrorSeverity.WARNING]
+        self.assertEqual(len(errors), 1)
         self.assertEqual(len(def_dict.defs), 0)
 
         # Good input string
         def_dict2 = DefinitionDict()
         def_dict2.add_definitions("(Definition/testdefplaceholder/#,(Acceleration/#,Item/TestDef2, Red))",
                                   self.hed_schema)
-        self.assertEqual(len(def_dict2.issues), 0)
+        self.assertEqual(len(def_dict2.issues), 1)
         self.assertEqual(len(def_dict2.defs), 1)
 
 

--- a/tests/models/test_sidecar.py
+++ b/tests/models/test_sidecar.py
@@ -3,7 +3,7 @@ import os
 import io
 import shutil
 
-from hed.errors import HedFileError, ValidationErrors
+from hed.errors import HedFileError, ValidationErrors, ErrorSeverity
 from hed.models import ColumnMetadata, HedString, Sidecar
 from hed import schema
 from hed.models import DefinitionDict, DefinitionEntry
@@ -115,10 +115,14 @@ class Test(unittest.TestCase):
         # If external defs are the same, no error
         duplicate_dict = sidecar.extract_definitions(hed_schema=self.hed_schema)
         issues = sidecar.validate(self.hed_schema, extra_def_dicts=duplicate_dict, error_handler=ErrorHandler(False))
-        self.assertEqual(len(issues), 0)
+        self.assertEqual(len(issues), 2)
+        errors = [issue for issue in issues if issue['severity'] < ErrorSeverity.WARNING]
+        self.assertEqual(len(errors), 0)
         test_dict = {"jsonfiledef3": DefinitionEntry("jsonfiledef3", None, False, None)}
         issues2 = sidecar.validate(self.hed_schema, extra_def_dicts=test_dict, error_handler=ErrorHandler(False))
-        self.assertEqual(len(issues2), 1)
+        self.assertEqual(len(issues2), 3)
+        errors = [issue for issue in issues2 if issue['severity'] < ErrorSeverity.WARNING]
+        self.assertEqual(len(errors), 1)
         self.assertTrue(issues2[0]['code'], ValidationErrors.DEFINITION_INVALID)
 
     def test_save_load(self):

--- a/tests/tools/analysis/test_hed_type_factors.py
+++ b/tests/tools/analysis/test_hed_type_factors.py
@@ -24,13 +24,14 @@ class Test(unittest.TestCase):
                 HedString(
                     '(Definition/Cond3/#, (Organizational-property/Condition-variable/Var3, Label/#, Ellipse, Cross))',
                     hed_schema=schema),
-                HedString('(Definition/Cond4, (Condition-variable, Apple, Banana))', hed_schema=schema),
-                HedString('(Definition/Cond5, (Condition-variable/Lumber, Apple, Banana))', hed_schema=schema),
-                HedString('(Definition/Cond6/#, (Condition-variable/Lumber, Label/#, Apple, Banana))',
+                HedString('(Definition/Cond4, (Condition-variable, Item, Circle))', hed_schema=schema),
+                HedString('(Definition/Cond5, (Condition-variable/Lumber, Item, Circle))', hed_schema=schema),
+                HedString('(Definition/Cond6/#, (Condition-variable/Lumber, Label/#, Item, Circle))',
                           hed_schema=schema)]
         def_dict = DefinitionDict()
         for value in defs:
             def_dict.check_for_definitions(value)
+        cls.setup_dict = def_dict
         test_strings1 = ["Sensory-event,(Def/Cond1,(Red, Blue, Condition-variable/Trouble),Onset)",
                          "(Def/Cond2,Onset),Green,Yellow, Def/Cond5, Def/Cond6/4",
                          "(Def/Cond1, Offset)",

--- a/tests/validator/test_def_validator.py
+++ b/tests/validator/test_def_validator.py
@@ -88,7 +88,7 @@ class Test(unittest.TestCase):
         def_dict.check_for_definitions(def_string, error_handler=error_handler)
         self.assertEqual(len(def_dict.issues), 0)
         def_dict2 = DefinitionDict()
-        def_dict2.add_definitions("(Definition/testdefplaceholder/#,(Acceleration/#,Item/TestDef2, Red))", self.hed_schema)
+        def_dict2.add_definitions("(Definition/testdefplaceholder/#,(Acceleration/#,Item, Red))", self.hed_schema)
         self.assertEqual(len(def_dict2.issues), 0)
         def_dict3 = DefinitionDict([def_dict, def_dict2])
         self.assertEqual(len(def_dict3.issues), 1)

--- a/tests/validator/test_hed_validator.py
+++ b/tests/validator/test_hed_validator.py
@@ -2,7 +2,7 @@ import unittest
 import os
 
 # from hed import
-from hed.errors import ErrorContext
+from hed.errors import ErrorContext, ErrorSeverity
 from hed import schema
 from hed.models import HedString, SpreadsheetInput, TabularInput, Sidecar
 from hed.validator import HedValidator
@@ -100,7 +100,8 @@ class Test(unittest.TestCase):
                                                   '../data/validator_tests/bids_events_bad_defs.json'))
         sidecar = Sidecar(json_path)
         issues = sidecar.validate(hed_schema)
-        self.assertEqual(len(issues), 8)
+        filtered_issues = [issue for issue in issues if issue['severity'] < ErrorSeverity.WARNING]
+        self.assertEqual(len(filtered_issues), 10)
         input_file = TabularInput(events_path, sidecar=sidecar)
 
         validation_issues = input_file.validate(hed_schema)
@@ -120,11 +121,11 @@ class Test(unittest.TestCase):
                                                   '../data/validator_tests/bids_events_bad_defs2.json'))
         sidecar = Sidecar(json_path)
         issues = sidecar.validate(hed_schema)
-        self.assertEqual(len(issues), 7)
+        self.assertEqual(len(issues), 8)
         input_file = TabularInput(events_path, sidecar=sidecar)
 
         validation_issues = input_file.validate(hed_schema)
-        self.assertEqual(len(validation_issues), 63)
+        self.assertEqual(len(validation_issues), 42)
 
     def test_file_bad_defs_in_spreadsheet(self):
         schema_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),


### PR DESCRIPTION
External DefinitionDict requires separate validation.  Previously it was assumed that externally-provided DefinitionDict were valid.