### PR TITLE
Fix double counting in TabularSummary counts

### DIFF
--- a/hed/tools/analysis/tabular_summary.py
+++ b/hed/tools/analysis/tabular_summary.py
@@ -238,13 +238,10 @@ class TabularSummary:
                 self.value_info[col_name][0] = self.value_info[col_name][0] + len(col_values)
                 self.value_info[col_name][1] = self.value_info[col_name][1] + 1
             else:
-                cat_counts = self.categorical_counts.get(col_name, [0, 0])
-                cat_counts[0] += len(col_values)
-                cat_counts[1] += 1
-                self.categorical_counts[col_name] = cat_counts
+                # _update_categorical accumulates, so pass only this dataframe's counts.
                 col_values = col_values.astype(str)
                 values = col_values.value_counts(ascending=True)
-                self._update_categorical(col_name, values, cat_counts)
+                self._update_categorical(col_name, values, [len(col_values), 1])
 
     def _update_dict_categorical(self, col_dict):
         """Update this summary with the categorical information in the dictionary from another summary.

--- a/tests/tools/analysis/test_tabular_summary.py
+++ b/tests/tools/analysis/test_tabular_summary.py
@@ -303,6 +303,20 @@ class Test(unittest.TestCase):
             self.assertGreater(counts[0], 0, f"Column {col_name} should have event count > 0")
             self.assertGreaterEqual(counts[1], 1, f"Column {col_name} should have been updated at least once")
 
+    def test_categorical_counts_not_doubled(self):
+        # categorical_counts must equal [total rows, files seen], accumulated across updates
+        stern_df = get_new_dataframe(self.stern_map_path)
+        n_rows = len(stern_df)
+
+        dict1 = TabularSummary()
+        dict1.update(stern_df)
+        for col_name, counts in dict1.categorical_counts.items():
+            self.assertEqual(counts, [n_rows, 1], f"{col_name} counts after one update")
+
+        dict1.update(stern_df)
+        for col_name, counts in dict1.categorical_counts.items():
+            self.assertEqual(counts, [2 * n_rows, 2], f"{col_name} counts after two updates")
+
     def test_categorical_limit_in_summary(self):
         # Test that categorical_limit appears in the summary output
         dict1 = TabularSummary(categorical_limit=10)


### PR DESCRIPTION
update_dataframe added a dataframe's row and file counts into categorical_counts and then passed the same list to _update_categorical, which added it again. Pass only the per-dataframe counts and let _update_categorical accumulate. Adds a regression test.